### PR TITLE
18 entity and enum typing error

### DIFF
--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/school/enums/HighSchool.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/school/enums/HighSchool.kt
@@ -7,18 +7,18 @@ enum class HighSchool(
     val schoolName: String
 ) {
 
-    GWANGJU_TECHNICAL_HighSchool("광주공업고등학교"),
-    KUMPA_TECHNICAL_HighSchool("금파공업고등학교"),
-    JEONNAM_TECHNICAL_HighSchool("전남공업고등학교"),
-    GWANGJU_GIRLS_COMMERCIAL_HighSchool("광주여자상업고등학교"),
-    JEONNAM_GIRLS_COMMERCIAL_HighSchool("전남여자상업고등학교"),
-    GWANGJU_NATURAL_SCIENCE_HighSchool("광주자연과학고등학교"),
-    GWANGJU_ELECTRONIC_TECHNICAL_HighSchool("광주전자공업고등학교"),
-    DONGIL_HIGH_SCHOOL_OF_FUTURE_SCIENCE_HighSchool("동일미래과학고등학교"),
+    GWANGJU_TECHNICAL_HIGH_SCHOOL("광주공업고등학교"),
+    KUMPA_TECHNICAL_HIGH_SCHOOL("금파공업고등학교"),
+    JEONNAM_TECHNICAL_HIGH_SCHOOL("전남공업고등학교"),
+    GWANGJU_GIRLS_COMMERCIAL_HIGH_SCHOOL("광주여자상업고등학교"),
+    JEONNAM_GIRLS_COMMERCIAL_HIGH_SCHOOL("전남여자상업고등학교"),
+    GWANGJU_NATURAL_SCIENCE_HIGH_SCHOOL("광주자연과학고등학교"),
+    GWANGJU_ELECTRONIC_TECHNICAL_HIGH_SCHOOL("광주전자공업고등학교"),
+    DONGIL_HIGH_SCHOOL_OF_FUTURE_SCIENCE_HIGH_SCHOOL("동일미래과학고등학교"),
     SEOJIN_GIRLS_HIGH_SCHOOL("서진여자고등학교"),
-    SUNGUI_SCIENCE_TECHNOLOGY_HighSchool("숭의과학기술고등학교"),
-    SONGWON_GIRLS_COMMERCIAL_HighSchool("송원여자상업고등학교"),
-    GWANGJU_AUTOMATIC_EQUIPMENT_TECHNICAL_HighSchool("광주자동화설비마이스터고등학교"),
-    GWANGJU_SOFTWARE_MEISTER_HighSchool("광주소프트웨어마이스터고등학교")
+    SUNGUI_SCIENCE_TECHNOLOGY_HIGH_SCHOOL("숭의과학기술고등학교"),
+    SONGWON_GIRLS_COMMERCIAL_HIGH_SCHOOL("송원여자상업고등학교"),
+    GWANGJU_AUTOMATIC_EQUIPMENT_TECHNICAL_HIGH_SCHOOL("광주자동화설비마이스터고등학교"),
+    GWANGJU_SOFTWARE_MEISTER_HIGH_SCHOOL("광주소프트웨어마이스터고등학교")
     ;
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivity.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivity.kt
@@ -22,7 +22,7 @@ class StudentActivity(
     val content: String,
 
     @Column(columnDefinition = "INT", nullable = false)
-    val credit: String,
+    val credit: Int,
 
     override val createdAt: LocalDateTime,
 


### PR DESCRIPTION
## 💡 개요
StudentActivity 엔티티와 HighSchool Enum에 있는 오타들을 수정했습니다
## 📃 작업내용
* StudentActivity credit의 자료형이 Int가 아닌 String으로 선언되어있던 오타를 수정했습니다
* HighSchool enum의 타입 대부분의 이름들이 소문자로 표기되어있던 오타를 수정했습니다