### PR TITLE
#44 HttpLoggingAspect 클래스 작성

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/common/aop/HttpLoggingAspect.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/common/aop/HttpLoggingAspect.kt
@@ -1,0 +1,88 @@
+package team.msg.common.aop
+
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Pointcut
+import org.aspectj.lang.reflect.CodeSignature
+import org.aspectj.lang.reflect.MethodSignature
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+import team.msg.common.logger.LoggerDelegator
+import java.util.*
+import kotlin.collections.HashMap
+import kotlin.collections.HashSet
+
+@Aspect
+@Component
+class HttpLoggingAspect {
+
+    private val log by LoggerDelegator()
+
+    @Pointcut("within(@org.springframework.web.bind.annotation.RestController *)")
+    fun onRequest() {}
+
+    @Around("onRequest()")
+    @Throws(Throwable::class)
+    fun logging(proceedingJoinPoint: ProceedingJoinPoint): Any? {
+        val request = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).request
+        val ip = request.remoteAddr
+        val method = request.method
+        val uri = request.requestURI
+        val sessionId = request.requestedSessionId
+        val params = request.queryString
+        val contentType = request.contentType
+        val userAgent = request.getHeader("User-Agent")
+        val signature: MethodSignature = proceedingJoinPoint.signature as MethodSignature
+        val className = signature.declaringType.simpleName
+        val methodName = signature.name
+        val headerNames = request.headerNames
+        val headerSet: MutableSet<String> = HashSet()
+
+        while (headerNames.hasMoreElements()) {
+            val headerName = headerNames.nextElement()
+            headerSet.add(headerName)
+        }
+        val code = UUID.randomUUID()
+        log.info(
+            "At {}#{} [Request:{}] IP: {}, Session-ID: {}, URI: {}, Params: {}, Content-Type: {}, User-Agent: {}, Headers: {}, Parameters: {}, Code: {}",
+            className, methodName, method, ip, sessionId, uri, params, contentType, userAgent, headerSet, params(proceedingJoinPoint), code
+        )
+        val result = proceedingJoinPoint.proceed()
+        when (result) {
+            is ResponseEntity<*> -> {
+                log.info(
+                    "At {}#{} [Response:{}] IP: {}, Session-ID: {}, Headers: {}, Response: {}, Status-Code: {}, Code: {}",
+                    className, methodName, method, ip,sessionId, result.headers, result.body, result.statusCode, code
+                )
+            }
+
+            null -> {
+                log.info(
+                    "At {}#{} [Response: null] IP: {}, Session-ID: {}, Code: {}",
+                    className, methodName, ip, sessionId, code
+                )
+            }
+
+            else -> {
+                throw RuntimeException("유효하지 않은 Controller 반환 타입입니다.")
+            }
+        }
+        return result
+    }
+
+    private fun params(joinPoint: JoinPoint): Map<*,*>? {
+        val codeSignature = joinPoint.signature as CodeSignature
+        val parameterNames = codeSignature.parameterNames
+        val args = joinPoint.args
+        val params: MutableMap<String,Any> = HashMap()
+
+        for (i in parameterNames.indices) {
+            params[parameterNames[i]] = args[i]
+        }
+        return params
+    }
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/common/init/DataInitializer.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/common/init/DataInitializer.kt
@@ -1,4 +1,4 @@
-package team.msg.common
+package team.msg.common.init
 
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener


### PR DESCRIPTION
## 💡 개요
RestController로 들어오는 http severt request, response, info를 로깅하는 aspect를 작성했습니다.

## 📃 작업내용
아래와 같은 내용을 로깅합니다

```kt
log.info(
            "At {}#{} [Request:{}] IP: {}, Session-ID: {}, URI: {}, Params: {}, Content-Type: {}, User-Agent: {}, Headers: {}, Parameters: {}, Code: {}",
            className, methodName, method, ip, sessionId, uri, params, contentType, userAgent, headerSet, params(proceedingJoinPoint), code
        )
```

- 각 request,response마다 고유한 id를 부여합니다.
- `ResponseEntity<*>`의 response 타입을 로깅하는 로직에서 ResponseEntity타입이 반환되지 않으면 유효하지 않은 컨트롤러 반환 타입의 메시지로 RuntimeException이 발생하게 됩니다.
