### PR TITLE
BaseUUIDEntity() Persistable 구현과 JpaRepository 기능 관련 이슈 해결 트러블슈팅

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -72,7 +72,6 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         val student = Student(
-            id = UUID.randomUUID(),
             user = user,
             club = club,
             grade = request.grade,
@@ -102,7 +101,6 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         val teacher = Teacher(
-            id = UUID.randomUUID(),
             user = user,
             club = club
         )
@@ -126,7 +124,6 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         val professor = Professor(
-            id = UUID.randomUUID(),
             user = user,
             club = club,
             university = request.university
@@ -151,7 +148,6 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         val government = Government(
-            id = UUID.randomUUID(),
             user = user,
             club = club,
             governmentName = request.governmentName
@@ -170,7 +166,6 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         val companyInstructor = CompanyInstructor(
-            id = UUID.randomUUID(),
             user = user,
             club = club,
             company = request.company
@@ -225,7 +220,6 @@ class AuthServiceImpl(
             throw AlreadyExistPhoneNumberException("이미 가입된 전화번호를 기입하였습니다. info : [ phoneNumber = $phoneNumber ]")
 
         val user = User(
-            id = UUID.randomUUID(),
             email = email,
             name = name,
             phoneNumber = phoneNumber,

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -29,7 +29,6 @@ class LectureServiceImpl(
         }
 
         val lecture = Lecture(
-            id = UUID.randomUUID(),
             user = user,
             name = request.name,
             startDate = request.startDate,

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -38,7 +38,6 @@ class StudentActivityServiceImpl(
             ?: throw TeacherNotFoundException("취업 동아리 선생님을 찾을 수 없습니다.")
 
         val studentActivity = StudentActivity(
-            id = UUID.randomUUID(),
             title = request.title,
             content = request.content,
             credit = request.credit,
@@ -66,15 +65,11 @@ class StudentActivityServiceImpl(
         val studentActivity = studentActivityRepository.findByIdAndStudent(id, student)
             ?: throw StudentActivityNotFoundException("학생 활동을 찾을 수 없습니다. info : [ studentActivityId = $id ]")
 
-        val updatedStudentActivity = StudentActivity(
-            id = studentActivity.id,
+        val updatedStudentActivity = studentActivity.updateStudentActivity(
             title = request.title,
             content = request.content,
             credit = request.credit,
-            activityDate = request.activityDate,
-            approveStatus = ApproveStatus.PENDING,
-            student = studentActivity.student,
-            teacher = studentActivity.teacher,
+            activityDate = request.activityDate
         )
 
         studentActivityRepository.save(updatedStudentActivity)

--- a/bitgouel-domain/build.gradle.kts
+++ b/bitgouel-domain/build.gradle.kts
@@ -13,6 +13,7 @@ bootJar.enabled = false
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis:2.7.5")
+    implementation("de.huxhorn.sulky:ulid:7.0")
 }
 
 allOpen {

--- a/bitgouel-domain/build.gradle.kts
+++ b/bitgouel-domain/build.gradle.kts
@@ -13,7 +13,6 @@ bootJar.enabled = false
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis:2.7.5")
-    implementation("de.huxhorn.sulky:ulid:7.0")
 }
 
 allOpen {

--- a/bitgouel-domain/src/main/kotlin/team/msg/common/entity/BaseUUIDEntity.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/common/entity/BaseUUIDEntity.kt
@@ -4,7 +4,12 @@ import javax.persistence.Column
 import javax.persistence.GeneratedValue
 import javax.persistence.Id
 import javax.persistence.MappedSuperclass
+import javax.persistence.PostLoad
+import javax.persistence.PostPersist
 import org.hibernate.annotations.GenericGenerator
+import org.hibernate.proxy.HibernateProxy
+import org.springframework.data.domain.Persistable
+import java.io.Serializable
 import java.util.*
 
 @MappedSuperclass
@@ -14,4 +19,41 @@ abstract class BaseUUIDEntity(
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
     @Column(columnDefinition = "BINARY(16)", nullable = false)
     open val id: UUID
-) : BaseTimeEntity()
+) : BaseTimeEntity(), Persistable<UUID> {
+
+    override fun getId(): UUID = id
+
+    @Transient
+    private var _isNew = true
+
+    override fun isNew(): Boolean = _isNew
+
+    @PostPersist
+    @PostLoad
+    protected fun load() {
+        _isNew = false
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null) {
+            return false
+        }
+
+        if (other !is HibernateProxy && this::class != other::class) {
+            return false
+        }
+
+        return id == getIdentifier(other)
+    }
+
+    private fun getIdentifier(obj: Any): Serializable {
+        return if (obj is HibernateProxy) {
+            obj.hibernateLazyInitializer.identifier
+        } else {
+            (obj as BaseUUIDEntity).id
+        }
+    }
+
+    override fun hashCode() = Objects.hashCode(id)
+
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/common/entity/BaseUUIDEntity.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/common/entity/BaseUUIDEntity.kt
@@ -14,18 +14,17 @@ import java.io.Serializable
 import java.util.*
 
 @MappedSuperclass
-abstract class BaseUUIDEntity(
+abstract class BaseUUIDEntity : BaseTimeEntity(), Persistable<UUID> {
+
     @Id
     @GeneratedValue(generator = "uuid2")
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
     @Column(columnDefinition = "BINARY(16)", nullable = false)
-    open val id: UUID
-) : BaseTimeEntity(), Persistable<UUID> {
+    private val id: UUID = UUID.randomUUID()
 
     @Column(name = "ulid", updatable = false, unique = true)
     private var ulid: String? = ULIDGenerator.generateULID()
 
-    override fun getId(): UUID = id
 
     @Transient
     private var _isNew = true

--- a/bitgouel-domain/src/main/kotlin/team/msg/common/entity/BaseUUIDEntity.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/common/entity/BaseUUIDEntity.kt
@@ -9,6 +9,7 @@ import javax.persistence.PostPersist
 import org.hibernate.annotations.GenericGenerator
 import org.hibernate.proxy.HibernateProxy
 import org.springframework.data.domain.Persistable
+import team.msg.common.ulid.ULIDGenerator
 import java.io.Serializable
 import java.util.*
 
@@ -20,6 +21,9 @@ abstract class BaseUUIDEntity(
     @Column(columnDefinition = "BINARY(16)", nullable = false)
     open val id: UUID
 ) : BaseTimeEntity(), Persistable<UUID> {
+
+    @Column(name = "ulid", updatable = false, unique = true)
+    private var ulid: String? = ULIDGenerator.generateULID()
 
     override fun getId(): UUID = id
 

--- a/bitgouel-domain/src/main/kotlin/team/msg/common/ulid/ULIDGenerator.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/common/ulid/ULIDGenerator.kt
@@ -1,0 +1,40 @@
+package team.msg.common.ulid
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.security.SecureRandom
+import java.time.Instant
+
+
+/**
+ * 직접 ULID를 생성하는 ULIDGenerator입니다.. ULID는 현재 시간 정보를 기반으로하며
+ * 보안 랜덤 값을 사용하여 16바이트의 바이트 배열을 생성합니다. 그런 다음 이를 문자열로 변환하여 ULID를 생성합니다.
+ */
+class ULIDGenerator private constructor() {
+    companion object {
+        private val random = SecureRandom()
+
+        fun generateULID(): String {
+            val milliseconds = Instant.now().toEpochMilli()
+
+            val bytes = ByteArray(16)
+            val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.BIG_ENDIAN)
+            buffer.putLong(milliseconds)
+            buffer.putLong(random.nextLong())
+
+            return bytes.toULIDString()
+        }
+
+        private fun ByteArray.toULIDString(): String {
+            val sb = StringBuilder()
+            forEachIndexed { index,byte ->
+                if (index == 6 || index == 8 || index == 10 || index == 12) {
+                    sb.append('-')
+                }
+                sb.append(((byte.toInt() shr 4) and 0xF).toString(16))
+                sb.append((byte.toInt() and 0xF).toString(16))
+            }
+            return sb.toString()
+        }
+    }
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/common/ulid/ULIDGenerator.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/common/ulid/ULIDGenerator.kt
@@ -7,7 +7,7 @@ import java.time.Instant
 
 
 /**
- * 직접 ULID를 생성하는 ULIDGenerator입니다.. ULID는 현재 시간 정보를 기반으로하며
+ * ULID를 생성하는 ULIDGenerator입니다. ULID는 현재 시간 정보를 기반으로하며
  * 보안 랜덤 값을 사용하여 16바이트의 바이트 배열을 생성합니다. 그런 다음 이를 문자열로 변환하여 ULID를 생성합니다.
  */
 class ULIDGenerator private constructor() {

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/admin/model/Admin.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/admin/model/Admin.kt
@@ -12,10 +12,11 @@ import java.util.*
 @Entity
 class Admin(
 
-    override val id: UUID,
-
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity() {
+
+    override fun getId(): UUID = id
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/bbozzak/model/Bbozzak.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/bbozzak/model/Bbozzak.kt
@@ -13,8 +13,6 @@ import java.util.UUID
 @Entity
 class Bbozzak(
 
-    override val id: UUID,
-
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -23,4 +21,8 @@ class Bbozzak(
     @JoinColumn(name = "club_id", nullable = false)
     val club: Club
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity() {
+
+    override fun getId(): UUID = id
+
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/company/model/CompanyInstructor.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/company/model/CompanyInstructor.kt
@@ -9,8 +9,6 @@ import javax.persistence.*
 @Entity
 class CompanyInstructor(
 
-    override val id: UUID,
-
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -22,4 +20,6 @@ class CompanyInstructor(
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
     val company: String
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity() {
+    override fun getId(): UUID = id
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/government/model/Government.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/government/model/Government.kt
@@ -14,8 +14,6 @@ import java.util.UUID
 @Entity
 class Government(
 
-    override val id: UUID,
-
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -27,4 +25,6 @@ class Government(
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
     val governmentName: String
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity() {
+    override fun getId(): UUID = id
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/Lecture.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/Lecture.kt
@@ -16,7 +16,6 @@ import java.util.UUID
 
 @Entity
 class Lecture(
-    override val id: UUID,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
@@ -53,4 +52,6 @@ class Lecture(
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
     var approveStatus: ApproveStatus = ApproveStatus.PENDING
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity() {
+    override fun getId(): UUID = id
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/RegisteredLecture.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/RegisteredLecture.kt
@@ -12,7 +12,6 @@ import java.util.UUID
 
 @Entity
 class RegisteredLecture(
-    override val id: UUID,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "student_id", columnDefinition = "BINARY(16)")
@@ -24,4 +23,6 @@ class RegisteredLecture(
 
     @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
     val completeDate: LocalDateTime
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity() {
+    override fun getId(): UUID = id
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/professor/model/Professor.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/professor/model/Professor.kt
@@ -14,8 +14,6 @@ import java.util.UUID
 @Entity
 class Professor(
 
-    override val id: UUID,
-
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -27,5 +25,6 @@ class Professor(
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
     val university: String
 
-) : BaseUUIDEntity(id) {
+) : BaseUUIDEntity() {
+    override fun getId(): UUID = id
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/Student.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/Student.kt
@@ -18,8 +18,6 @@ import java.util.UUID
 @Entity
 class Student(
 
-    override val id: UUID,
-
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -47,4 +45,6 @@ class Student(
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
     val studentRole: StudentRole
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity() {
+    override fun getId(): UUID = id
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivity.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivity.kt
@@ -16,23 +16,21 @@ import java.util.*
 @Entity
 class StudentActivity(
 
-    override val id: UUID,
-
     @Column(columnDefinition = "VARCHAR(100)", nullable = false)
-    val title: String,
+    var title: String,
 
     @Column(columnDefinition = "VARCHAR(1000)", nullable = false)
-    val content: String,
+    var content: String,
 
     @Column(columnDefinition = "INT", nullable = false)
-    val credit: Int,
+    var credit: Int,
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
-    val approveStatus: ApproveStatus,
+    var approveStatus: ApproveStatus,
 
     @Column(nullable = false, columnDefinition = "DATETIME(6)")
-    val activityDate: LocalDateTime,
+    var activityDate: LocalDateTime,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "student_id", columnDefinition = "BINARY(16)", nullable = false)
@@ -42,5 +40,15 @@ class StudentActivity(
     @JoinColumn(name = "teacher_id", columnDefinition = "BINARY(16)", nullable = false)
     val teacher: Teacher
 
-) : BaseUUIDEntity(id){
+) : BaseUUIDEntity(){
+
+    override fun getId(): UUID = id
+
+    fun updateStudentActivity(title: String, content: String, credit: Int, activityDate: LocalDateTime): StudentActivity {
+        this.title = title
+        this.content = content
+        this.credit = credit
+        this.approveStatus = ApproveStatus.PENDING
+        return this
+    }
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/teacher/model/Teacher.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/teacher/model/Teacher.kt
@@ -14,8 +14,6 @@ import java.util.UUID
 @Entity
 class Teacher(
 
-    override val id: UUID,
-
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -24,4 +22,6 @@ class Teacher(
     @JoinColumn(name = "club_id", nullable = false)
     val club: Club
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity() {
+    override fun getId(): UUID = id
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/model/User.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/model/User.kt
@@ -12,8 +12,6 @@ import java.util.*
 @Entity
 class User(
 
-    override val id: UUID,
-
     @Column(columnDefinition = "VARCHAR(100)", nullable = false)
     val email: String,
 
@@ -34,4 +32,6 @@ class User(
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
     val approveStatus: ApproveStatus
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity() {
+    override fun getId(): UUID = id
+}


### PR DESCRIPTION
## 💡 개요
Persistable 클래스를 상속해 엔티티 관련 처리 연산에 효율을 올리도록 하겠습니다.

Persistable을 사용하기 위해 다음과 같은 이슈들을 해결해야합니다.

## 📃 작업내용

### **update 작업 수행시 select문 발생합니다.**
그래서 ULID를 Entity를 생성할 때 함께 생성해서 영속화를 하면 `EntityManager.persist` 함수가 아닌 `EntityManager.merge` 함수가 호출됩니다. 그래서 아래와 같이 저장하기 전에 Primary Key를 가진 데이터가 존재하는지 여부를 확인하는 쿼리가 한번 실행됨을 볼 수 있습니다.

> ULID 생성 이유는 UUID를 사용시 정렬과 같은 작업에서 성능이슈가 있을 수 있기 때문에 ulid를 부여해 엔티티의 순서를 보장하고 정렬에서 성능상 이점을 가져갈 수 있습니다.

ULIDGenerator로 ULID 생성 알고리즘을 작성한 후 엔티티 생성 시 ULID를 할당해줍니다.

<br>

### **Persistable사용시 delete 작업이 처리되지 않습니다.**

> 그 이유는 JpaRepository deletee구현체에서 isNew()가 true라면 delete연산이 수행되지 않습니다.

```kt
@Override
@Transactional
@SuppressWarnings("unchecked")
public void delete(T entity) {

  Assert.notNull(entity, "Entity must not be null!");

  if (entityInformation.isNew(entity)) {
    return;
  }

  Class<?> type = ProxyUtils.getUserClass(entity);

  T existing = (T) em.find(type, entityInformation.getId(entity));

  // if the entity to be deleted doesn't exist, delete is a NOOP
  if (existing == null) {
    return;
  }

  em.remove(em.contains(entity) ? entity : em.merge(entity));
}
```

#### 해결
→ 이 부분을 해결하기 위해 JPA의 `@PostPersist`와 `@PostLoad`를 활용하기로 했습니다. `@PostPersist`와 `@PostLoad`는 JPA의 수명주기 이벤트에 대한 콜백 방법을 정의하는 것으로 각각 영속화 이후와 영속화한 데이터를 조회한 이후에 함수가 실행되도록 할 수 있습니다. 위 예시 코드에 추가해보겠습니다. isNew의 상태를 관리해야 하므로 `isNew` Property를 추가하고 영속화는 하지 않도록 `@Transient`를 선언해주어야합니다.

<br>

### **동일성 보장**
Hibernate에서 `etchType.LAZY`로 설정된 객체는 실제 객체가 아닌 `하이버네이트 프록시 객체`가 반환되기때문에 엔티티간의 동일성이 보장되지 않습니다. (엔티티는 PrimaryKey의 값으로 동등성을 보장한다. 그렇기에 동일성을 보장하는 `equals를 재정의해 id값을 비교`하게 해야한다. 왜냐하면 인스턴스의 값은 변할 수 있기때문에 같은 id의 엔티티라도 모든 필드가 같다는 보장은 할 수 없지만 id가 같으면 같은 엔티티인 것이다. 그래서 id만 같다면 동일성도 보장해야한다.)

#### 해결
-> FetchType.EAGER을 통해 해결할수도 있지만 차라리 equals의 구현을 **HibernateProxy 엔티티가 아닐때 동일성을 보장**하도록 재정의해서 해결합니다. + hashCode()도 따라서 구현
