### PR TITLE
#56 학생 활동 업데이트 히스토리 저장 이벤트 핸들러 작성

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/handler/StudentActivityEventHandler.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/handler/StudentActivityEventHandler.kt
@@ -1,0 +1,35 @@
+package team.msg.domain.student.handler
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import team.msg.common.enum.ApproveStatus
+import team.msg.domain.student.event.UpdateStudentActivityEvent
+import team.msg.domain.student.model.StudentActivityHistory
+import team.msg.domain.student.repository.StudentActivityHistoryRepository
+
+@Component
+class StudentActivityEventHandler(
+    private val studentActivityHistoryRepository: StudentActivityHistoryRepository
+) {
+
+    /**
+     * studentActivity의 update 이벤트가 발행되면 히스토리를 저장하는 핸들러입니다.
+     * @param studentActivity update 이벤트
+     */
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    fun updateStudentActivityHandler(event: UpdateStudentActivityEvent) {
+        val studentActivity = event.studentActivity
+        val studentActivityHistory = StudentActivityHistory(
+            title = studentActivity.title,
+            content = studentActivity.content,
+            credit = studentActivity.credit,
+            approveStatus = ApproveStatus.APPROVED,
+            activityDate = studentActivity.activityDate,
+            student = studentActivity.student,
+            teacher = studentActivity.teacher,
+            studentActivityId = studentActivity.id
+        )
+        studentActivityHistoryRepository.save(studentActivityHistory)
+    }
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -57,7 +57,7 @@ class StudentActivityServiceImpl(
     /**
      * 학생 활동을 업데이트하는 비지니스 로직입니다
      * applicationEventPublisher로부터 학생 활동 업데이트 이벤트를 발행합니다.
-     * @param UpdateStudentActivityRequest
+     * @param 학생 활동을 수정하기 위해 데이터를 담은 request Dto와 학생 정보 활동 id
      */
     @Transactional(rollbackFor = [Exception::class])
     override fun updateStudentActivity(id: UUID, request: UpdateStudentActivityRequest) {

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -57,7 +57,7 @@ class StudentActivityServiceImpl(
     /**
      * 학생 활동을 업데이트하는 비지니스 로직입니다
      * applicationEventPublisher로부터 학생 활동 업데이트 이벤트를 발행합니다.
-     * @param 학생 활동을 수정하기 위해 데이터를 담은 request Dto와 학생 정보 활동 id
+     * @param 학생 활동 id, 학생 활동을 수정하기 위한 데이터들을 담은 request Dto,
      */
     @Transactional(rollbackFor = [Exception::class])
     override fun updateStudentActivity(id: UUID, request: UpdateStudentActivityRequest) {

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -1,9 +1,11 @@
 package team.msg.domain.student.service
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.msg.common.enum.ApproveStatus
 import team.msg.common.util.UserUtil
+import team.msg.domain.student.event.UpdateStudentActivityEvent
 import team.msg.domain.student.exception.StudentActivityNotFoundException
 import team.msg.domain.student.exception.StudentNotFoundException
 import team.msg.domain.student.model.StudentActivity
@@ -20,12 +22,13 @@ class StudentActivityServiceImpl(
     private val userUtil: UserUtil,
     private val studentRepository: StudentRepository,
     private val teacherRepository: TeacherRepository,
-    private val studentActivityRepository: StudentActivityRepository
+    private val studentActivityRepository: StudentActivityRepository,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : StudentActivityService {
 
     /**
-     * 학생 활동을 생성하는 비지니스 로직입니다
-     * @param CreateStudentActivityRequest
+     * 학생 활동을 생성하는 비지니스 로직입니다.
+     * @param 학생 활동을 생성하기 위해 데이터를 담은 request Dto
      */
     @Transactional(rollbackFor = [Exception::class])
     override fun createStudentActivity(request: CreateStudentActivityRequest) {
@@ -53,6 +56,7 @@ class StudentActivityServiceImpl(
 
     /**
      * 학생 활동을 업데이트하는 비지니스 로직입니다
+     * applicationEventPublisher로부터 학생 활동 업데이트 이벤트를 발행합니다.
      * @param UpdateStudentActivityRequest
      */
     @Transactional(rollbackFor = [Exception::class])
@@ -72,6 +76,7 @@ class StudentActivityServiceImpl(
             activityDate = request.activityDate
         )
 
+        applicationEventPublisher.publishEvent(UpdateStudentActivityEvent(studentActivity))
         studentActivityRepository.save(updatedStudentActivity)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -55,9 +55,9 @@ class StudentActivityServiceImpl(
 
 
     /**
-     * 학생 활동을 업데이트하는 비지니스 로직입니다
+     * 학생 활동을 업데이트하는 비지니스 로직입니다.
      * applicationEventPublisher로부터 학생 활동 업데이트 이벤트를 발행합니다.
-     * @param 학생 활동 id, 학생 활동을 수정하기 위한 데이터들을 담은 request Dto,
+     * @param 학생 활동 id, 학생 활동을 수정하기 위한 데이터들을 담은 request Dto
      */
     @Transactional(rollbackFor = [Exception::class])
     override fun updateStudentActivity(id: UUID, request: UpdateStudentActivityRequest) {

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/event/UpdateStudentActivityEvent.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/event/UpdateStudentActivityEvent.kt
@@ -1,0 +1,11 @@
+package team.msg.domain.student.event
+
+import team.msg.domain.student.model.StudentActivity
+
+/**
+ * StudentActivity의 업데이트하는 이벤트를 나타냅니다.
+ * StudentActivity를 구독자에게 알리기 위해서 사용됩니다.
+ */
+data class UpdateStudentActivityEvent(
+    val studentActivity: StudentActivity
+)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivityHistory.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivityHistory.kt
@@ -1,0 +1,52 @@
+package team.msg.domain.student.model
+
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.FetchType
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import team.msg.common.entity.BaseUUIDEntity
+import team.msg.common.enum.ApproveStatus
+import team.msg.domain.teacher.model.Teacher
+import java.time.LocalDateTime
+import java.util.*
+
+
+/**
+ * StudentActivity의 History를 저장하는 엔티티입니다.
+ */
+@Entity
+class StudentActivityHistory(
+    @Column(columnDefinition = "VARCHAR(100)", nullable = false)
+    var title: String,
+
+    @Column(columnDefinition = "VARCHAR(1000)", nullable = false)
+    var content: String,
+
+    @Column(columnDefinition = "INT", nullable = false)
+    var credit: Int,
+
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "VARCHAR(10)", nullable = false)
+    var approveStatus: ApproveStatus,
+
+    @Column(nullable = false, columnDefinition = "DATETIME(6)")
+    var activityDate: LocalDateTime,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "student_id", columnDefinition = "BINARY(16)", nullable = false)
+    val student: Student,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "teacher_id", columnDefinition = "BINARY(16)", nullable = false)
+    val teacher: Teacher,
+
+    @Column(name = "student_activity_id", columnDefinition = "BINARY(16)", nullable = false)
+    val studentActivityId: UUID
+) : BaseUUIDEntity() {
+
+    override fun getId(): UUID = id
+
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/StudentActivityHistoryRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/StudentActivityHistoryRepository.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.student.repository
+
+import org.springframework.data.repository.CrudRepository
+import team.msg.domain.student.model.StudentActivityHistory
+import java.util.UUID
+
+interface StudentActivityHistoryRepository : CrudRepository<StudentActivityHistory, UUID> {
+}


### PR DESCRIPTION
## 💡 개요
학생 활동을 업데이트 했을 때 PENDING으로 처리됩니다.
그렇기에 기존 업데이트 전 활동을 보존하기 위해 학생활동 History를 저장하는 로직을 처리합니다.

## 📃 작업내용
다음과 같은 프로세스를 가집니다.
**학생 활동 업데이트 -> 학생 활동 업데이트 이벤트 발행 -> 학생 활동 핸들러에서 히스토리 저장 관련 로직 처리**

History는 업데이트 되기 전 정보를 저장해야하기 때문에 트랜잭션 페이즈를 `Before Commit`으로 설정했습니다.

> 학생 활동 히스토리는 기본적인 StudentActivity의 필드와 StudentActivity의 아이디만 가지고 있습니다.

## 🎸 기타
학생활동히스토리 엔티티에는 student, teacher의 엔티티를 `FetchType.LAZY`로 연관관계가 매핑되어있지만 단지 History READ를 위해 목적을 가지고 사용될 필드라면 이름만 저장하는 것도 어떨까 하는 생각이 들기는 합니다. 그러나 부가적인 변경사항이나 기능을 위해 안정적으로 일단 객체로 연관관계를 매핑해두었습니다.


## 🎤 추가

@ani2689 

학생 활동 전체 조회 기능을 구현하는 과정에서 그저 Approved의 학생활동을 가져오는 것이 아닌 PENDING상태지만 History가 있는지 판별을 해야합니다. ApproveStatus는 업데이트 대기중 상태가 따로 존재하지 않기 때문에 필터링을 처리해야합니다. findAll()로 전부 가져와 필터링을 하는 과정을 밟을 수 있지만 쿼리지향적으로 처리할 수 있을 것 같습니다.

**다음과 같은 솔루션을 제시해드리겠습니다.**
-> select 쿼리로 approve상태인 학생 활동과 pending이면서 history가 존재하는 학생활동을 전부 가져온다. 그렇게 되면 여기서 조회한 pending 상태의 학생 활동들은 전부 히스토리가 존재한다는 것을 보장할 수 있다.
