### PR TITLE
#62 getIdentifier 충돌 이슈 해결

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -74,6 +74,7 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         val student = Student(
+            id = UUID.randomUUID(),
             user = user,
             club = club,
             grade = request.grade,
@@ -103,6 +104,7 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         val teacher = Teacher(
+            id = UUID.randomUUID(),
             user = user,
             club = club
         )
@@ -126,6 +128,7 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         val professor = Professor(
+            id = UUID.randomUUID(),
             user = user,
             club = club,
             university = request.university
@@ -150,6 +153,7 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         val government = Government(
+            id = UUID.randomUUID(),
             user = user,
             club = club,
             governmentName = request.governmentName
@@ -168,6 +172,7 @@ class AuthServiceImpl(
         val club = queryClub(request.highSchool, request.clubName)
 
         val companyInstructor = CompanyInstructor(
+            id = UUID.randomUUID(),
             user = user,
             club = club,
             company = request.company
@@ -243,6 +248,7 @@ class AuthServiceImpl(
             throw AlreadyExistPhoneNumberException("이미 가입된 전화번호를 기입하였습니다. info : [ phoneNumber = $phoneNumber ]")
 
         val user = User(
+            id = UUID.randomUUID(),
             email = email,
             name = name,
             phoneNumber = phoneNumber,
@@ -267,4 +273,5 @@ class AuthServiceImpl(
 
         return club
     }
+
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -35,6 +35,7 @@ class LectureServiceImpl(
         }
 
         val lecture = Lecture(
+            id = UUID.randomUUID(),
             user = user,
             name = request.name,
             startDate = request.startDate,
@@ -61,7 +62,19 @@ class LectureServiceImpl(
         if(lecture.approveStatus == ApproveStatus.APPROVED)
             throw AlreadyApprovedLectureException("이미 개설 신청이 승인된 강의입니다. info : [ lectureId = $id ]")
 
-        val approveLecture = lecture.updateApproveStatus(ApproveStatus.APPROVED)
+        val approveLecture = Lecture(
+            id = lecture.id,
+            user = lecture.user,
+            name = lecture.name,
+            startDate = lecture.startDate,
+            endDate = lecture.endDate,
+            completeDate = lecture.completeDate,
+            content = lecture.content,
+            lectureType = lecture.lectureType,
+            credit = lecture.credit,
+            instructor = lecture.user.name,
+            maxRegisteredUser = lecture.maxRegisteredUser
+        )
 
         lectureRepository.save(approveLecture)
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -22,7 +22,7 @@ class LectureServiceImpl(
 
     /**
      * 강의 개설을 처리하는 비지니스 로직입니다.
-     * @param CreateLectureRequest
+     * @param 생성할 강의의 데이터를 담은 request Dto
      */
     @Transactional(rollbackFor = [Exception::class])
     override fun createLecture(request: CreateLectureRequest) {
@@ -53,7 +53,7 @@ class LectureServiceImpl(
 
     /**
      * 강의 개설 신청을 수락하는 비지니스 로직입니다.
-     * @param UUID
+     * @param 승인할 강의의 id
      */
     @Transactional(rollbackFor = [Exception::class])
     override fun approveLecture(id: UUID) {
@@ -81,7 +81,7 @@ class LectureServiceImpl(
 
     /**
      * 강의 개설 신청을 거절하는 비지니스 로직입니다.
-     * @param UUID
+     * @param 거절할 강의의 id
      */
     @Transactional(rollbackFor = [Exception::class])
     override fun rejectLecture(id: UUID) {

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/handler/StudentActivityEventHandler.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/handler/StudentActivityEventHandler.kt
@@ -7,6 +7,7 @@ import team.msg.common.enum.ApproveStatus
 import team.msg.domain.student.event.UpdateStudentActivityEvent
 import team.msg.domain.student.model.StudentActivityHistory
 import team.msg.domain.student.repository.StudentActivityHistoryRepository
+import java.util.*
 
 @Component
 class StudentActivityEventHandler(
@@ -21,6 +22,7 @@ class StudentActivityEventHandler(
     fun updateStudentActivityHandler(event: UpdateStudentActivityEvent) {
         val studentActivity = event.studentActivity
         val studentActivityHistory = StudentActivityHistory(
+            id = UUID.randomUUID(),
             title = studentActivity.title,
             content = studentActivity.content,
             credit = studentActivity.credit,

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -41,6 +41,7 @@ class StudentActivityServiceImpl(
             ?: throw TeacherNotFoundException("취업 동아리 선생님을 찾을 수 없습니다.")
 
         val studentActivity = StudentActivity(
+            id = UUID.randomUUID(),
             title = request.title,
             content = request.content,
             credit = request.credit,
@@ -69,13 +70,16 @@ class StudentActivityServiceImpl(
         val studentActivity = studentActivityRepository.findByIdAndStudent(id, student)
             ?: throw StudentActivityNotFoundException("학생 활동을 찾을 수 없습니다. info : [ studentActivityId = $id ]")
 
-        val updatedStudentActivity = studentActivity.updateStudentActivity(
+        val updatedStudentActivity = StudentActivity(
+            id = studentActivity.id,
             title = request.title,
             content = request.content,
             credit = request.credit,
-            activityDate = request.activityDate
+            activityDate = request.activityDate,
+            approveStatus = ApproveStatus.PENDING,
+            student = studentActivity.student,
+            teacher = studentActivity.teacher
         )
-
         applicationEventPublisher.publishEvent(UpdateStudentActivityEvent(studentActivity))
         studentActivityRepository.save(updatedStudentActivity)
     }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/admin/model/Admin.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/admin/model/Admin.kt
@@ -12,11 +12,11 @@ import java.util.*
 @Entity
 class Admin(
 
+    @get:JvmName("getIdentifier")
+    override var id: UUID,
+
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?
 
-) : BaseUUIDEntity() {
-
-    override fun getId(): UUID = id
-}
+) : BaseUUIDEntity(id)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/bbozzak/model/Bbozzak.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/bbozzak/model/Bbozzak.kt
@@ -13,6 +13,9 @@ import java.util.UUID
 @Entity
 class Bbozzak(
 
+    @get:JvmName("getIdentifier")
+    override var id: UUID,
+
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -21,8 +24,4 @@ class Bbozzak(
     @JoinColumn(name = "club_id", nullable = false)
     val club: Club
 
-) : BaseUUIDEntity() {
-
-    override fun getId(): UUID = id
-
-}
+) : BaseUUIDEntity(id)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/company/model/CompanyInstructor.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/company/model/CompanyInstructor.kt
@@ -9,6 +9,9 @@ import javax.persistence.*
 @Entity
 class CompanyInstructor(
 
+    @get:JvmName("getIdentifier")
+    override var id: UUID,
+
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -20,6 +23,6 @@ class CompanyInstructor(
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
     val company: String
 
-) : BaseUUIDEntity() {
-    override fun getId(): UUID = id
+) : BaseUUIDEntity(id) {
+
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/government/model/Government.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/government/model/Government.kt
@@ -14,6 +14,9 @@ import java.util.UUID
 @Entity
 class Government(
 
+    @get:JvmName("getIdentifier")
+    override var id: UUID,
+
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -25,6 +28,4 @@ class Government(
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
     val governmentName: String
 
-) : BaseUUIDEntity() {
-    override fun getId(): UUID = id
-}
+) : BaseUUIDEntity(id)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/Lecture.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/Lecture.kt
@@ -17,6 +17,9 @@ import java.util.UUID
 @Entity
 class Lecture(
 
+    @get:JvmName("getIdentifier")
+    override var id: UUID,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User,
@@ -52,11 +55,4 @@ class Lecture(
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
     var approveStatus: ApproveStatus = ApproveStatus.PENDING
-) : BaseUUIDEntity() {
-    override fun getId(): UUID = id
-
-    fun updateApproveStatus(approveStatus: ApproveStatus): Lecture {
-        this.approveStatus = approveStatus
-        return this
-    }
-}
+) : BaseUUIDEntity(id)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/RegisteredLecture.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/RegisteredLecture.kt
@@ -13,6 +13,9 @@ import java.util.UUID
 @Entity
 class RegisteredLecture(
 
+    @get:JvmName("getIdentifier")
+    override var id: UUID,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "student_id", columnDefinition = "BINARY(16)")
     val student: Student,
@@ -23,6 +26,4 @@ class RegisteredLecture(
 
     @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
     val completeDate: LocalDateTime
-) : BaseUUIDEntity() {
-    override fun getId(): UUID = id
-}
+) : BaseUUIDEntity(id)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/professor/model/Professor.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/professor/model/Professor.kt
@@ -14,6 +14,9 @@ import java.util.UUID
 @Entity
 class Professor(
 
+    @get:JvmName("getIdentifier")
+    override var id: UUID,
+
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -25,6 +28,6 @@ class Professor(
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
     val university: String
 
-) : BaseUUIDEntity() {
+) : BaseUUIDEntity(id) {
     override fun getId(): UUID = id
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/Student.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/Student.kt
@@ -18,6 +18,9 @@ import java.util.UUID
 @Entity
 class Student(
 
+    @get:JvmName("getIdentifier")
+    override var id: UUID,
+
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -45,6 +48,5 @@ class Student(
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
     val studentRole: StudentRole
 
-) : BaseUUIDEntity() {
-    override fun getId(): UUID = id
+) : BaseUUIDEntity(id) {
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivity.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivity.kt
@@ -16,6 +16,9 @@ import java.util.*
 @Entity
 class StudentActivity(
 
+    @get:JvmName("getIdentifier")
+    override var id: UUID,
+
     @Column(columnDefinition = "VARCHAR(100)", nullable = false)
     var title: String,
 
@@ -40,15 +43,4 @@ class StudentActivity(
     @JoinColumn(name = "teacher_id", columnDefinition = "BINARY(16)", nullable = false)
     val teacher: Teacher
 
-) : BaseUUIDEntity(){
-
-    override fun getId(): UUID = id
-
-    fun updateStudentActivity(title: String, content: String, credit: Int, activityDate: LocalDateTime): StudentActivity {
-        this.title = title
-        this.content = content
-        this.credit = credit
-        this.approveStatus = ApproveStatus.PENDING
-        return this
-    }
-}
+) : BaseUUIDEntity(id)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivityHistory.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivityHistory.kt
@@ -19,6 +19,10 @@ import java.util.*
  */
 @Entity
 class StudentActivityHistory(
+
+    @get:JvmName("getIdentifier")
+    override var id: UUID,
+
     @Column(columnDefinition = "VARCHAR(100)", nullable = false)
     var title: String,
 
@@ -45,8 +49,6 @@ class StudentActivityHistory(
 
     @Column(name = "student_activity_id", columnDefinition = "BINARY(16)", nullable = false)
     val studentActivityId: UUID
-) : BaseUUIDEntity() {
-
-    override fun getId(): UUID = id
+) : BaseUUIDEntity(id) {
 
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/teacher/model/Teacher.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/teacher/model/Teacher.kt
@@ -14,6 +14,9 @@ import java.util.UUID
 @Entity
 class Teacher(
 
+    @get:JvmName("getIdentifier")
+    override var id: UUID,
+
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -22,6 +25,4 @@ class Teacher(
     @JoinColumn(name = "club_id", nullable = false)
     val club: Club
 
-) : BaseUUIDEntity() {
-    override fun getId(): UUID = id
-}
+) : BaseUUIDEntity(id)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/model/User.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/model/User.kt
@@ -12,6 +12,9 @@ import java.util.*
 @Entity
 class User(
 
+    @get:JvmName("getIdentifier")
+    override var id: UUID,
+
     @Column(columnDefinition = "VARCHAR(100)", nullable = false)
     val email: String,
 
@@ -32,6 +35,4 @@ class User(
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
     val approveStatus: ApproveStatus
 
-) : BaseUUIDEntity() {
-    override fun getId(): UUID = id
-}
+) : BaseUUIDEntity(id)


### PR DESCRIPTION
## 💡 개요
아이디 필드에 자동으로 생기는 게터 getId와 Persistable의 getId의 이름 충돌이 있어
@JvmName어노테이션으로 id값의 게터이름을 getIdentifier로 지정해 충돌을 막았습니다.
isNew()의 로직을 변경했습니다.

## 📃 작업내용
BaseUUIDEntity `isNew()`, id + All Of Entity

## 🎸 기타
업데이트, 객체생성 관련할때 아이디값 다시 지정해서 인스턴스 생성해주시면 됩니다.
