### PR TITLE
# 57 회원 탈퇴 로직

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/exception/AdminNotFoundException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/exception/AdminNotFoundException.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.admin.exception
+
+import team.msg.domain.admin.exception.constant.AdminErrorCode
+import team.msg.global.error.exception.BitgouelException
+
+class AdminNotFoundException(
+    message: String
+) : BitgouelException(message, AdminErrorCode.ADMIN_NOT_FOUND.status)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/exception/constant/AdminErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/exception/constant/AdminErrorCode.kt
@@ -1,8 +1,7 @@
 package team.msg.domain.admin.exception.constant
 
 enum class AdminErrorCode(
-    val message: String,
     val status: Int
 ) {
-    ADMIN_NOT_FOUND("존재하지 않는 어드민 입니다.", 404)
+    ADMIN_NOT_FOUND(404)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/exception/constant/AdminErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/exception/constant/AdminErrorCode.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.admin.exception.constant
+
+enum class AdminErrorCode(
+    val message: String,
+    val status: Int
+) {
+    ADMIN_NOT_FOUND("존재하지 않는 어드민 입니다.", 404)
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/exception/constant/AuthErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/exception/constant/AuthErrorCode.kt
@@ -1,13 +1,12 @@
 package team.msg.domain.auth.exception.constant
 
 enum class AuthErrorCode(
-    val message: String,
     val status: Int
 ) {
-    ALREADY_EXIST_EMAIL("이미 가입된 이메일입니다.", 409),
-    ALREADY_EXIST_PHONE_NUMBER("이미 가입된 전화번호입니다.", 409),
-    MISMATCH_PASSWORD("일치하지 않는 비밀번호입니다.", 401),
-    UNAPPROVED_USER("아직 회원가입 대기 상태입니다.", 403),
-    INVALID_TOKEN("유효하지 않은 토큰입니다.", 401),
-    REFRESH_TOKEN_NOT_FOUND("존재하지 않는 리프레시 토큰입니다.", 404)
+    ALREADY_EXIST_EMAIL(409),
+    ALREADY_EXIST_PHONE_NUMBER(409),
+    MISMATCH_PASSWORD(401),
+    UNAPPROVED_USER(403),
+    INVALID_TOKEN(401),
+    REFRESH_TOKEN_NOT_FOUND(404)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/AuthController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/AuthController.kt
@@ -75,7 +75,7 @@ class AuthController(
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 
-    @DeleteMapping
+    @DeleteMapping("/withdraw")
     fun withdraw(): ResponseEntity<Void> {
         authService.withdraw()
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/AuthController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/AuthController.kt
@@ -74,4 +74,10 @@ class AuthController(
         authService.logout(refreshToken)
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
+
+    @DeleteMapping
+    fun withdraw(): ResponseEntity<Void> {
+        authService.withdraw()
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+    }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthService.kt
@@ -12,4 +12,5 @@ interface AuthService {
     fun login(request: LoginRequest): TokenResponse
     fun reissueToken(refreshToken: String): TokenResponse
     fun logout(refreshToken: String)
+    fun withdraw()
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -6,12 +6,7 @@ import org.springframework.transaction.annotation.Transactional
 import team.msg.common.enum.ApproveStatus
 import team.msg.common.util.SecurityUtil
 import team.msg.common.util.UserUtil
-import team.msg.domain.auth.exception.AlreadyExistEmailException
-import team.msg.domain.auth.exception.AlreadyExistPhoneNumberException
-import team.msg.domain.auth.exception.InvalidRefreshTokenException
-import team.msg.domain.auth.exception.MisMatchPasswordException
-import team.msg.domain.auth.exception.RefreshTokenNotFoundException
-import team.msg.domain.auth.exception.UnApprovedUserException
+import team.msg.domain.auth.exception.*
 import team.msg.domain.auth.presentation.data.request.*
 import team.msg.domain.auth.presentation.data.response.TokenResponse
 import team.msg.domain.auth.repository.RefreshTokenRepository
@@ -238,6 +233,9 @@ class AuthServiceImpl(
     @Transactional(rollbackFor = [Exception::class])
     override fun withdraw() {
         val user = userUtil.queryCurrentUser()
+
+
+        userRepository.delete(user)
     }
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -243,6 +243,8 @@ class AuthServiceImpl(
         val user = userUtil.queryCurrentUser()
 
         applicationEventPublisher.publishEvent(WithdrawUserEvent(user))
+
+        userRepository.delete(user)
     }
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -1,5 +1,6 @@
 package team.msg.domain.auth.service
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -28,6 +29,7 @@ import team.msg.domain.student.repository.StudentRepository
 import team.msg.domain.teacher.model.Teacher
 import team.msg.domain.teacher.repository.TeacherRepository
 import team.msg.domain.user.enums.Authority
+import team.msg.domain.user.event.WithdrawUserEvent
 import team.msg.domain.user.exception.UserNotFoundException
 import team.msg.domain.user.model.User
 import team.msg.domain.user.repository.UserRepository
@@ -49,7 +51,8 @@ class AuthServiceImpl(
     private val jwtTokenGenerator: JwtTokenGenerator,
     private val jwtTokenParser: JwtTokenParser,
     private val refreshTokenRepository: RefreshTokenRepository,
-    private val userUtil: UserUtil
+    private val userUtil: UserUtil,
+    private val applicationEventPublisher: ApplicationEventPublisher
 ) : AuthService {
 
     /**
@@ -239,7 +242,7 @@ class AuthServiceImpl(
     override fun withdraw() {
         val user = userUtil.queryCurrentUser()
 
-
+        applicationEventPublisher.publishEvent(WithdrawUserEvent(user))
 
         userRepository.delete(user)
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -243,8 +243,6 @@ class AuthServiceImpl(
         val user = userUtil.queryCurrentUser()
 
         applicationEventPublisher.publishEvent(WithdrawUserEvent(user))
-
-        userRepository.delete(user)
     }
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -240,6 +240,7 @@ class AuthServiceImpl(
         val user = userUtil.queryCurrentUser()
 
 
+
         userRepository.delete(user)
     }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -208,6 +208,7 @@ class AuthServiceImpl(
         val user = userRepository.findByIdOrNull(token.userId)
             ?: throw UserNotFoundException("존재하지 않는 유저입니다. info : [ userId = ${token.userId} ]")
 
+        refreshTokenRepository.deleteById(refreshToken)
         return jwtTokenGenerator.generateToken(user.id, user.authority)
     }
 
@@ -229,6 +230,14 @@ class AuthServiceImpl(
             throw UserNotFoundException("존재하지 않는 유저입니다. info : [ userId =  ${token.userId} ]")
 
         refreshTokenRepository.delete(token)
+    }
+
+    /**
+     * 회원탈퇴를 처리하는 메서드입니다.
+     */
+    @Transactional(rollbackFor = [Exception::class])
+    override fun withdraw() {
+        val user = userUtil.queryCurrentUser()
     }
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/bbozzak/exception/BbozzakNotFoundException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/bbozzak/exception/BbozzakNotFoundException.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.bbozzak.exception
+
+import team.msg.domain.bbozzak.exception.constant.BbozzakErrorCode
+import team.msg.global.error.exception.BitgouelException
+
+class BbozzakNotFoundException(
+    message: String
+) : BitgouelException(message, BbozzakErrorCode.BBOZZAK_NOT_FOUND.status)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/bbozzak/exception/constant/BbozzakErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/bbozzak/exception/constant/BbozzakErrorCode.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.bbozzak.exception.constant
+
+enum class BbozzakErrorCode(
+    val message: String,
+    val status: Int
+) {
+    BBOZZAK_NOT_FOUND("존재하지 않는 뽀짝샘입니다.", 404)
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/bbozzak/exception/constant/BbozzakErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/bbozzak/exception/constant/BbozzakErrorCode.kt
@@ -1,8 +1,7 @@
 package team.msg.domain.bbozzak.exception.constant
 
 enum class BbozzakErrorCode(
-    val message: String,
     val status: Int
 ) {
-    BBOZZAK_NOT_FOUND("존재하지 않는 뽀짝샘입니다.", 404)
+    BBOZZAK_NOT_FOUND(404)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/exception/constant/ClubErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/exception/constant/ClubErrorCode.kt
@@ -1,8 +1,7 @@
 package team.msg.domain.club.exception.constant
 
 enum class ClubErrorCode(
-    val message: String,
     val status: Int
 ) {
-    CLUB_NOT_FOUND("존재하지 않는 동아리입니다.", 404)
+    CLUB_NOT_FOUND(404)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/company/exception/CompanyNotFoundException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/company/exception/CompanyNotFoundException.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.company.exception
+
+import team.msg.domain.company.exception.constant.CompanyErrorCode
+import team.msg.global.error.exception.BitgouelException
+
+class CompanyNotFoundException(
+    message: String
+) : BitgouelException(message, CompanyErrorCode.COMPANY_NOT_FOUND.status)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/company/exception/constant/CompanyErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/company/exception/constant/CompanyErrorCode.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.company.exception.constant
+
+enum class CompanyErrorCode(
+    val message: String,
+    val status: Int
+) {
+    COMPANY_NOT_FOUND("존재하지 않는 기업 강사 입니다.", 404)
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/company/exception/constant/CompanyErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/company/exception/constant/CompanyErrorCode.kt
@@ -1,8 +1,7 @@
 package team.msg.domain.company.exception.constant
 
 enum class CompanyErrorCode(
-    val message: String,
     val status: Int
 ) {
-    COMPANY_NOT_FOUND("존재하지 않는 기업 강사 입니다.", 404)
+    COMPANY_NOT_FOUND(404)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/government/GovernmentNotFoundException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/government/GovernmentNotFoundException.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.government
+
+import team.msg.domain.government.exception.constant.GovernmentErrorCode
+import team.msg.global.error.exception.BitgouelException
+
+class GovernmentNotFoundException(
+    message: String
+) : BitgouelException(message, GovernmentErrorCode.GOVERNMENT_NOT_FOUND.status)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/government/exception/constant/GovernmentErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/government/exception/constant/GovernmentErrorCode.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.government.exception.constant
+
+enum class GovernmentErrorCode(
+    val message: String,
+    val status: Int
+) {
+    GOVERNMENT_NOT_FOUND("존재하지 않는 유관 기관 입니다.", 404)
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/government/exception/constant/GovernmentErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/government/exception/constant/GovernmentErrorCode.kt
@@ -1,8 +1,7 @@
 package team.msg.domain.government.exception.constant
 
 enum class GovernmentErrorCode(
-    val message: String,
     val status: Int
 ) {
-    GOVERNMENT_NOT_FOUND("존재하지 않는 유관 기관 입니다.", 404)
+    GOVERNMENT_NOT_FOUND(404)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/exception/constant/LectureErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/exception/constant/LectureErrorCode.kt
@@ -1,12 +1,9 @@
 package team.msg.domain.lecture.exception.constant
 
 enum class LectureErrorCode(
-    val message: String,
     val status: Int
 ){
-    INVALID_LECTURE_TYPE("유효하지 않은 강의 구분입니다.", 400),
-
-    LECTURE_NOT_FOUND("존재하지 않는 강의입니다.", 404),
-
-    ALREADY_APPROVED_LECTURE("이미 개설 신청이 승인된 강의입니다.",409)
+    INVALID_LECTURE_TYPE(400),
+    LECTURE_NOT_FOUND(404),
+    ALREADY_APPROVED_LECTURE(409)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/professor/exception/ProfessorNotFoundException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/professor/exception/ProfessorNotFoundException.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.professor.exception
+
+import team.msg.domain.professor.exception.constant.ProfessorErrorCode
+import team.msg.global.error.exception.BitgouelException
+
+class ProfessorNotFoundException(
+    message: String
+) : BitgouelException(message, ProfessorErrorCode.PROFESSOR_NOT_FOUND.status)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/professor/exception/constant/ProfessorErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/professor/exception/constant/ProfessorErrorCode.kt
@@ -1,8 +1,7 @@
 package team.msg.domain.professor.exception.constant
 
 enum class ProfessorErrorCode(
-    val message: String,
     val status: Int
 ) {
-    PROFESSOR_NOT_FOUND("존재하지 않는 대학 교수입니다.", 404)
+    PROFESSOR_NOT_FOUND(404)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/professor/exception/constant/ProfessorErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/professor/exception/constant/ProfessorErrorCode.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.professor.exception.constant
+
+enum class ProfessorErrorCode(
+    val message: String,
+    val status: Int
+) {
+    PROFESSOR_NOT_FOUND("존재하지 않는 대학 교수입니다.", 404)
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/school/exception/constant/SchoolErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/school/exception/constant/SchoolErrorCode.kt
@@ -1,8 +1,7 @@
 package team.msg.domain.school.exception.constant
 
 enum class SchoolErrorCode(
-    val message: String,
     val status: Int
 ) {
-    SCHOOL_NOT_FOUND("이미 가입된 정보입니다.", 403)
+    SCHOOL_NOT_FOUND(403)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/exception/constant/StudentActivityErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/exception/constant/StudentActivityErrorCode.kt
@@ -1,8 +1,7 @@
 package team.msg.domain.student.exception.constant
 
 enum class StudentActivityErrorCode(
-    val message: String,
     val status: Int
 ) {
-    STUDENT_ACTIVITY_NOT_FOUND("학생 활동을 찾을 수 없습니다", 404)
+    STUDENT_ACTIVITY_NOT_FOUND(404)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/exception/constant/StudentErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/exception/constant/StudentErrorCode.kt
@@ -1,8 +1,7 @@
 package team.msg.domain.student.exception.constant
 
 enum class StudentErrorCode(
-    val message: String,
     val status: Int
 ) {
-    STUDENT_NOT_FOUND("학생을 찾을 수 없습니다.", 404)
+    STUDENT_NOT_FOUND(404)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/teacher/exception/TeacherNotFoundException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/teacher/exception/TeacherNotFoundException.kt
@@ -5,5 +5,4 @@ import team.msg.global.error.exception.BitgouelException
 
 class TeacherNotFoundException(
     message: String
-) : BitgouelException(message, TeacherErrorCode.TEACHER_NOT_FOUND.status) {
-}
+) : BitgouelException(message, TeacherErrorCode.TEACHER_NOT_FOUND.status)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/teacher/exception/constant/TeacherErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/teacher/exception/constant/TeacherErrorCode.kt
@@ -1,8 +1,7 @@
 package team.msg.domain.teacher.exception.constant
 
 enum class TeacherErrorCode(
-    val message: String,
     val status: Int
 ) {
-    TEACHER_NOT_FOUND("취업 동아리 선생님을 찾을 수 없습니다.", 404)
+    TEACHER_NOT_FOUND(404)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/user/exception/constant/UserErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/user/exception/constant/UserErrorCode.kt
@@ -1,8 +1,7 @@
 package team.msg.domain.user.exception.constant
 
 enum class UserErrorCode(
-    val message: String,
     val status: Int
 ) {
-    USER_NOT_FOUND("존재하지 않는 유저입니다.", 404)
+    USER_NOT_FOUND(404)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/user/handler/UserEventHandler.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/user/handler/UserEventHandler.kt
@@ -82,10 +82,10 @@ class UserEventHandler(
                 professorRepository.delete(professor)
             }
             ROLE_COMPANY_INSTRUCTOR -> {
-                val company = companyInstructorRepository.findByUser(user)
+                val companyInstructor = companyInstructorRepository.findByUser(user)
                     ?: throw CompanyNotFoundException("존재하지 않는 기업 강사 입니다. info : [ userId = ${user.id} ]")
 
-                companyInstructorRepository.delete(company)
+                companyInstructorRepository.delete(companyInstructor)
             }
             ROLE_GOVERNMENT -> {
                 val government = governmentRepository.findByUser(user)
@@ -96,7 +96,6 @@ class UserEventHandler(
 
             else -> throw UnApprovedUserException("회원가입 승인 대기 중인 유저입니다. info : [ userId = ${user.id} ]")
         }
-
 
         userRepository.delete(user)
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/user/handler/UserEventHandler.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/user/handler/UserEventHandler.kt
@@ -1,0 +1,103 @@
+package team.msg.domain.user.handler
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import team.msg.domain.admin.exception.AdminNotFoundException
+import team.msg.domain.admin.repository.AdminRepository
+import team.msg.domain.auth.exception.UnApprovedUserException
+import team.msg.domain.bbozzak.exception.BbozzakNotFoundException
+import team.msg.domain.bbozzak.repository.BbozzakRepository
+import team.msg.domain.company.exception.CompanyNotFoundException
+import team.msg.domain.company.repository.CompanyInstructorRepository
+import team.msg.domain.government.GovernmentNotFoundException
+import team.msg.domain.government.repository.GovernmentRepository
+import team.msg.domain.lecture.repository.RegisteredLectureRepository
+import team.msg.domain.professor.exception.ProfessorNotFoundException
+import team.msg.domain.professor.repository.ProfessorRepository
+import team.msg.domain.student.exception.StudentNotFoundException
+import team.msg.domain.student.repository.StudentActivityRepository
+import team.msg.domain.student.repository.StudentRepository
+import team.msg.domain.teacher.exception.TeacherNotFoundException
+import team.msg.domain.teacher.repository.TeacherRepository
+import team.msg.domain.user.enums.Authority.*
+import team.msg.domain.user.event.WithdrawUserEvent
+import team.msg.domain.user.repository.UserRepository
+
+@Component
+class UserEventHandler(
+    private val userRepository: UserRepository,
+    private val studentRepository: StudentRepository,
+    private val studentActivityRepository: StudentActivityRepository,
+    private val bbozzakRepository: BbozzakRepository,
+    private val teacherRepository: TeacherRepository,
+    private val professorRepository: ProfessorRepository,
+    private val companyInstructorRepository: CompanyInstructorRepository,
+    private val governmentRepository: GovernmentRepository,
+    private val registeredLectureRepository: RegisteredLectureRepository,
+    private val adminRepository: AdminRepository
+) {
+
+    /**
+     * User 의 delete 이벤트가 발행되면 User 를 삭제하는 핸들입니다.
+     * @param user delete 이벤트
+     */
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    fun withdrawUserHandler(event: WithdrawUserEvent) {
+        val user = event.user
+
+        when (user.authority) {
+            ROLE_STUDENT -> {
+                val student = studentRepository.findByUser(user)
+                    ?: throw StudentNotFoundException("존재하지 않는 학생 입니다. info : [ userId = ${user.id} ]")
+                val studentActivity = studentActivityRepository.findAllByStudent(student)
+                val registeredLecture = registeredLectureRepository.findAllByStudent(student)
+
+                studentActivityRepository.deleteAll(studentActivity)
+                registeredLectureRepository.deleteAll(registeredLecture)
+                studentRepository.delete(student)
+            }
+            ROLE_ADMIN -> {
+                val admin = adminRepository.findByUser(user)
+                    ?: throw AdminNotFoundException("존재하지 않는 어드민 입니다. info : [userId = ${user.id} ]")
+
+                adminRepository.delete(admin)
+            }
+            ROLE_BBOZZAK -> {
+                val bbozzak = bbozzakRepository.findByUser(user)
+                    ?: throw BbozzakNotFoundException("존재하지 않는 뽀짝샘 입니다. info : [ userId = ${user.id} ]")
+
+                bbozzakRepository.delete(bbozzak)
+            }
+            ROLE_TEACHER -> {
+                val teacher = teacherRepository.findByUser(user)
+                    ?: throw TeacherNotFoundException("존재하지 않는 선생님 입니다. info : [ userId = ${user.id} ]")
+
+                teacherRepository.delete(teacher)
+            }
+            ROLE_PROFESSOR -> {
+                val professor = professorRepository.findByUser(user)
+                    ?: throw ProfessorNotFoundException("존재하지 않는 대학 교수 입니다. info : [ userId = ${user.id} ]")
+
+                professorRepository.delete(professor)
+            }
+            ROLE_COMPANY_INSTRUCTOR -> {
+                val company = companyInstructorRepository.findByUser(user)
+                    ?: throw CompanyNotFoundException("존재하지 않는 기업 강사 입니다. info : [ userId = ${user.id} ]")
+
+                companyInstructorRepository.delete(company)
+            }
+            ROLE_GOVERNMENT -> {
+                val government = governmentRepository.findByUser(user)
+                    ?: throw GovernmentNotFoundException("존재하지 않는 유관 기관 입니다. info : [userId = ${user.id} ]")
+
+                governmentRepository.delete(government)
+            }
+
+            else -> throw UnApprovedUserException("회원가입 승인 대기 중인 유저입니다. info : [ userId = ${user.id} ]")
+        }
+
+
+        userRepository.delete(user)
+    }
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/user/handler/UserEventHandler.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/user/handler/UserEventHandler.kt
@@ -96,7 +96,5 @@ class UserEventHandler(
 
             else -> throw UnApprovedUserException("회원가입 승인 대기 중인 유저입니다. info : [ userId = ${user.id} ]")
         }
-
-        userRepository.delete(user)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/user/handler/UserEventHandler.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/user/handler/UserEventHandler.kt
@@ -71,7 +71,7 @@ class UserEventHandler(
             }
             ROLE_TEACHER -> {
                 val teacher = teacherRepository.findByUser(user)
-                    ?: throw TeacherNotFoundException("존재하지 않는 선생님 입니다. info : [ userId = ${user.id} ]")
+                    ?: throw TeacherNotFoundException("존재하지 않는 취동샘 입니다. info : [ userId = ${user.id} ]")
 
                 teacherRepository.delete(teacher)
             }

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -53,6 +53,7 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.POST, "/auth/login").permitAll()
             .mvcMatchers(HttpMethod.PATCH, "/auth").permitAll()
             .mvcMatchers(HttpMethod.DELETE, "/auth").authenticated()
+            .mvcMatchers(HttpMethod.DELETE, "/auth/withdraw").authenticated()
 
             // activity
             .mvcMatchers(HttpMethod.POST, "/activity").hasRole(STUDENT)

--- a/bitgouel-domain/src/main/kotlin/team/msg/common/entity/BaseUUIDEntity.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/common/entity/BaseUUIDEntity.kt
@@ -1,41 +1,33 @@
 package team.msg.common.entity
-
-import javax.persistence.Column
-import javax.persistence.GeneratedValue
-import javax.persistence.Id
-import javax.persistence.MappedSuperclass
-import javax.persistence.PostLoad
-import javax.persistence.PostPersist
 import org.hibernate.annotations.GenericGenerator
 import org.hibernate.proxy.HibernateProxy
 import org.springframework.data.domain.Persistable
 import team.msg.common.ulid.ULIDGenerator
-import java.io.Serializable
 import java.util.*
+import javax.persistence.Column
+import javax.persistence.GeneratedValue
+import javax.persistence.Id
+import javax.persistence.MappedSuperclass
 
 @MappedSuperclass
-abstract class BaseUUIDEntity : BaseTimeEntity(), Persistable<UUID> {
+abstract class BaseUUIDEntity(
 
     @Id
     @GeneratedValue(generator = "uuid2")
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
     @Column(columnDefinition = "BINARY(16)", nullable = false)
-    private val id: UUID = UUID.randomUUID()
+    @get:JvmName(name = "getIdentifier")
+    open var id: UUID = UUID(0, 0)
+) : BaseTimeEntity(), Persistable<UUID> {
 
     @Column(name = "ulid", updatable = false, unique = true)
-    private var ulid: String? = ULIDGenerator.generateULID()
+    var ulid: String? = ULIDGenerator.generateULID()
 
-
-    @Transient
-    private var _isNew = true
-
-    override fun isNew(): Boolean = _isNew
-
-    @PostPersist
-    @PostLoad
-    protected fun load() {
-        _isNew = false
+    override fun isNew(): Boolean = (id == UUID(0,0)).also { new ->
+        if(new) id = UUID.randomUUID()
     }
+
+    override fun getId(): UUID? = id
 
     override fun equals(other: Any?): Boolean {
         if (other == null) {
@@ -46,14 +38,10 @@ abstract class BaseUUIDEntity : BaseTimeEntity(), Persistable<UUID> {
             return false
         }
 
-        return id == getIdentifier(other)
-    }
-
-    private fun getIdentifier(obj: Any): Serializable {
-        return if (obj is HibernateProxy) {
-            obj.hibernateLazyInitializer.identifier
+        return id == if (other is HibernateProxy) {
+            other.hibernateLazyInitializer.identifier
         } else {
-            (obj as BaseUUIDEntity).id
+            (other as BaseUUIDEntity).id
         }
     }
 

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/admin/repository/AdminRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/admin/repository/AdminRepository.kt
@@ -2,6 +2,9 @@ package team.msg.domain.admin.repository
 
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.admin.model.Admin
+import team.msg.domain.user.model.User
 import java.util.UUID
 
-interface AdminRepository : CrudRepository<Admin, UUID>
+interface AdminRepository : CrudRepository<Admin,UUID> {
+    fun findByUser(user: User): Admin?
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/bbozzak/repository/BbozzakRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/bbozzak/repository/BbozzakRepository.kt
@@ -2,6 +2,9 @@ package team.msg.domain.bbozzak.repository
 
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.bbozzak.model.Bbozzak
+import team.msg.domain.user.model.User
 import java.util.UUID
 
-interface BbozzakRepository : CrudRepository<Bbozzak, UUID>
+interface BbozzakRepository : CrudRepository<Bbozzak,UUID> {
+    fun findByUser(user: User): Bbozzak?
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/company/model/CompanyInstructor.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/company/model/CompanyInstructor.kt
@@ -23,6 +23,4 @@ class CompanyInstructor(
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
     val company: String
 
-) : BaseUUIDEntity(id) {
-
-}
+) : BaseUUIDEntity(id)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/company/repository/CompanyInstructorRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/company/repository/CompanyInstructorRepository.kt
@@ -2,7 +2,9 @@ package team.msg.domain.company.repository
 
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.company.model.CompanyInstructor
+import team.msg.domain.user.model.User
 import java.util.UUID
 
 interface CompanyInstructorRepository : CrudRepository<CompanyInstructor, UUID> {
+    fun findByUser(user: User): CompanyInstructor?
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/government/repository/GovernmentRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/government/repository/GovernmentRepository.kt
@@ -2,8 +2,9 @@ package team.msg.domain.government.repository
 
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.government.model.Government
+import team.msg.domain.user.model.User
 import java.util.UUID
 
 interface GovernmentRepository : CrudRepository<Government, UUID> {
-    
+    fun findByUser(user: User): Government?
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/RegisteredLectureRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/RegisteredLectureRepository.kt
@@ -2,6 +2,9 @@ package team.msg.domain.lecture.repository
 
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.lecture.model.RegisteredLecture
+import team.msg.domain.student.model.Student
 import java.util.UUID
 
-interface RegisteredLectureRepository : CrudRepository<RegisteredLecture, UUID>
+interface RegisteredLectureRepository : CrudRepository<RegisteredLecture,UUID> {
+    fun findAllByStudent(student: Student): List<RegisteredLecture>
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/professor/repository/ProfessorRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/professor/repository/ProfessorRepository.kt
@@ -2,7 +2,9 @@ package team.msg.domain.professor.repository
 
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.professor.model.Professor
+import team.msg.domain.user.model.User
 import java.util.UUID
 
 interface ProfessorRepository : CrudRepository<Professor, UUID> {
+    fun findByUser(user: User): Professor?
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/Student.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/Student.kt
@@ -18,6 +18,9 @@ import java.util.UUID
 @Entity
 class Student(
 
+    @get:JvmName(name = "getIdentifier")
+    override var id: UUID,
+
     @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.MERGE])
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -45,6 +48,4 @@ class Student(
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
     val studentRole: StudentRole
 
-) : BaseUUIDEntity() {
-    override fun getId(): UUID = id
-}
+) : BaseUUIDEntity(id)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivity.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivity.kt
@@ -1,17 +1,11 @@
 package team.msg.domain.student.model
 
-import javax.persistence.Column
-import javax.persistence.Entity
-import javax.persistence.EnumType
-import javax.persistence.Enumerated
-import javax.persistence.FetchType
-import javax.persistence.JoinColumn
-import javax.persistence.ManyToOne
 import team.msg.common.entity.BaseUUIDEntity
 import team.msg.common.enum.ApproveStatus
 import team.msg.domain.teacher.model.Teacher
 import java.time.LocalDateTime
 import java.util.*
+import javax.persistence.*
 
 @Entity
 class StudentActivity(

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivityHistory.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivityHistory.kt
@@ -1,18 +1,11 @@
 package team.msg.domain.student.model
 
-import javax.persistence.Column
-import javax.persistence.Entity
-import javax.persistence.EnumType
-import javax.persistence.Enumerated
-import javax.persistence.FetchType
-import javax.persistence.JoinColumn
-import javax.persistence.ManyToOne
 import team.msg.common.entity.BaseUUIDEntity
 import team.msg.common.enum.ApproveStatus
 import team.msg.domain.teacher.model.Teacher
 import java.time.LocalDateTime
 import java.util.*
-
+import javax.persistence.*
 
 /**
  * StudentActivity의 History를 저장하는 엔티티입니다.
@@ -49,6 +42,5 @@ class StudentActivityHistory(
 
     @Column(name = "student_activity_id", columnDefinition = "BINARY(16)", nullable = false)
     val studentActivityId: UUID
-) : BaseUUIDEntity(id) {
 
-}
+) : BaseUUIDEntity(id)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/StudentActivityRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/StudentActivityRepository.kt
@@ -7,4 +7,5 @@ import java.util.*
 
 interface StudentActivityRepository : JpaRepository<StudentActivity, UUID> {
     fun findByIdAndStudent(id: UUID, student: Student): StudentActivity?
+    fun findAllByStudent(student: Student): List<StudentActivity>
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/teacher/repository/TeacherRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/teacher/repository/TeacherRepository.kt
@@ -3,8 +3,10 @@ package team.msg.domain.teacher.repository
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.club.model.Club
 import team.msg.domain.teacher.model.Teacher
+import team.msg.domain.user.model.User
 import java.util.UUID
 
 interface TeacherRepository : CrudRepository<Teacher, UUID> {
     fun findByClub(club: Club): Teacher?
+    fun findByUser(user: User): Teacher?
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/event/DeleteUserEvent.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/event/DeleteUserEvent.kt
@@ -1,0 +1,11 @@
+package team.msg.domain.user.event
+
+import team.msg.domain.user.model.User
+
+/**
+ * User 가 withdraw 하는 이벤트를 나타냅니다.
+ * User withdraw 를 구독자에게 알리기 위해서 사용됩니다.
+ */
+data class DeleteUserEvent(
+    val user: User
+)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/event/WithdrawUserEvent.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/event/WithdrawUserEvent.kt
@@ -6,6 +6,6 @@ import team.msg.domain.user.model.User
  * User 가 withdraw 하는 이벤트를 나타냅니다.
  * User withdraw 를 구독자에게 알리기 위해서 사용됩니다.
  */
-data class DeleteUserEvent(
+data class WithdrawUserEvent(
     val user: User
 )

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/model/User.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/model/User.kt
@@ -12,6 +12,9 @@ import java.util.*
 @Entity
 class User(
 
+    @get:JvmName("getIdentifier")
+    override var id: UUID,
+
     @Column(columnDefinition = "VARCHAR(100)", nullable = false)
     val email: String,
 
@@ -32,6 +35,4 @@ class User(
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
     val approveStatus: ApproveStatus
 
-) : BaseUUIDEntity() {
-    override fun getId(): UUID = id
-}
+) : BaseUUIDEntity(id)


### PR DESCRIPTION
## 💡 개요
회원 탈퇴 로직
## 📃 작업내용
회원 탈퇴 -> 회원 탈퇴 이벤트 발행 -> 회원 탈퇴 이벤트 핸들러에서 회원 탈퇴 로직 처리
phase 를 Before Commit 으로 설정
Authority when 문에서 else 일 때는 예외를 던져주었습니다.
## 🎸 기타
Inquery 또는 Post 같은 아직 만들어 놓지 않은 Entity 를 나중에 추가할 때 회원 탈퇴 로직에서 같이 삭제 해주시면 될 것 같습니다.