### PR TITLE
79 feat/docker compose redis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-jdk-slim
 WORKDIR /app
-ARG JAR_FILE=build/libs/*.jar
+ARG JAR_FILE=bitgouel-api/build/libs/*.jar
 COPY ${JAR_FILE} bitgouel-api.jar
 ENV TZ=Asia/Seoul
 CMD ["java", "-jar", "-Dspring.profiles.active=prod", "bitgouel-api.jar"]

--- a/bitgouel-api/src/main/kotlin/team/msg/global/config/RedisConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/config/RedisConfig.kt
@@ -11,14 +11,14 @@ import org.springframework.data.redis.serializer.StringRedisSerializer
 @Configuration
 class RedisConfig(
     @Value("spring.redis.host")
-    val host: String,
+    val host: String = "localhost",
 
     @Value("spring.redis.port")
-    val port: Int
+    val port: String = "6379"
 ) {
 
     @Bean
-    fun redisConnectionFactory(): RedisConnectionFactory = LettuceConnectionFactory(host, port)
+    fun redisConnectionFactory(): RedisConnectionFactory = LettuceConnectionFactory(host, port.toInt())
 
     @Bean
     fun redisTemplate(): RedisTemplate<String, Int> {

--- a/bitgouel-api/src/main/kotlin/team/msg/global/config/RedisConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/config/RedisConfig.kt
@@ -1,0 +1,31 @@
+package team.msg.global.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+class RedisConfig(
+    @Value("spring.redis.host")
+    val host: String,
+
+    @Value("spring.redis.port")
+    val port: Int
+) {
+
+    @Bean
+    fun redisConnectionFactory(): RedisConnectionFactory = LettuceConnectionFactory(host, port)
+
+    @Bean
+    fun redisTemplate(): RedisTemplate<String, Int> {
+        val redisTemplate = RedisTemplate<String, Int>()
+        redisTemplate.keySerializer = StringRedisSerializer()
+        redisTemplate.valueSerializer = StringRedisSerializer()
+        redisTemplate.setConnectionFactory(redisConnectionFactory())
+        return redisTemplate
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.7"
+
+services:
+  redis:
+    image: redis
+    container_name: redis
+    hostname: redis
+    ports:
+      - "6379:6379"
+  springboot:
+    container_name: springboot
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    ports:
+      - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,7 @@ version: "3.7"
 services:
   redis:
     image: redis
-    container_name: redis
-    hostname: redis
+    container_name: bitgouel-redis
+    hostname: bitgouel-redis
     ports:
       - "6379:6379"
-  springboot:
-    container_name: springboot
-    build:
-      context: .
-      dockerfile: ./Dockerfile
-    ports:
-      - "8080:8080"


### PR DESCRIPTION
## 💡 개요
docker compose (redis 환경 구성) 작성
RedisConfig 클래스 작성

## 📃 작업내용
redis는 main api 서버만 사용하고 있으니 elasticache를 사용하지않고 
Docker Compose를 통해서 사용하도록 하겠습니다.

\+ Dockerfile에 jar파일을 COPY하는 부분에서 bitgouel-api 모듈 경로 명시가 되어있지않아 이미지가 copy되지 않는 이슈를 해결했습니다.