### PR TITLE
101 feature/setting querydsl

### DIFF
--- a/bitgouel-api/build.gradle.kts
+++ b/bitgouel-api/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.2")
     implementation("org.springframework.boot:spring-boot-starter-security")
     testImplementation("org.springframework.security:spring-security-test")
+    implementation("com.querydsl:querydsl-jpa:5.0.0")
 
     implementation(project(":bitgouel-domain"))
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -4,7 +4,7 @@ import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import team.msg.common.enum.ApproveStatus
+import team.msg.common.enums.ApproveStatus
 import team.msg.common.util.SecurityUtil
 import team.msg.common.util.UserUtil
 import team.msg.domain.auth.exception.*

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/CreateLectureRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/CreateLectureRequest.kt
@@ -1,6 +1,6 @@
 package team.msg.domain.lecture.presentation.data.request
 
-import team.msg.domain.lecture.enum.LectureType
+import team.msg.domain.lecture.enums.LectureType
 import java.time.LocalDateTime
 
 data class CreateLectureRequest (

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/QueryAllLectureRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/QueryAllLectureRequest.kt
@@ -1,7 +1,7 @@
 package team.msg.domain.lecture.presentation.data.request
 
-import team.msg.common.enum.ApproveStatus
-import team.msg.domain.lecture.enum.LectureType
+import team.msg.common.enums.ApproveStatus
+import team.msg.domain.lecture.enums.LectureType
 
 data class QueryAllLectureRequest (
     val lectureType: LectureType?,

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
@@ -1,7 +1,7 @@
 package team.msg.domain.lecture.presentation.data.response
 import org.springframework.data.domain.Page
-import team.msg.domain.lecture.enum.LectureStatus
-import team.msg.domain.lecture.enum.LectureType
+import team.msg.domain.lecture.enums.LectureStatus
+import team.msg.domain.lecture.enums.LectureType
 import team.msg.domain.lecture.model.Lecture
 import java.time.LocalDateTime
 import java.util.*

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/web/CreateLectureWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/web/CreateLectureWebRequest.kt
@@ -8,7 +8,7 @@ import javax.validation.constraints.FutureOrPresent
 import javax.validation.constraints.Min
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
-import team.msg.domain.lecture.enum.LectureType
+import team.msg.domain.lecture.enums.LectureType
 import java.time.LocalDateTime
 
 data class CreateLectureWebRequest(

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/web/QueryAllLecturesWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/web/QueryAllLecturesWebRequest.kt
@@ -3,8 +3,8 @@ package team.msg.domain.lecture.presentation.web
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
 import org.springframework.web.bind.annotation.RequestParam
-import team.msg.common.enum.ApproveStatus
-import team.msg.domain.lecture.enum.LectureType
+import team.msg.common.enums.ApproveStatus
+import team.msg.domain.lecture.enums.LectureType
 
 data class QueryAllLecturesWebRequest(
     @RequestParam

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -88,10 +88,7 @@ class LectureServiceImpl(
 
         val response = AllLecturesResponse(
             lectures.map {
-                val headCount = if(it.approveStatus == ApproveStatus.APPROVED)
-                    registeredLectureRepository.countByLecture(it)
-                else
-                    0
+                val headCount = registeredLectureRepository.countByLecture(it)
                 LectureResponse.of(it,headCount)
             }
         )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -88,7 +88,11 @@ class LectureServiceImpl(
 
         val response = AllLecturesResponse(
             lectures.map {
-                LectureResponse.of(it, registeredLectureRepository.findAllByLecture(it).size)
+                val headCount = if(it.approveStatus == ApproveStatus.APPROVED)
+                    registeredLectureRepository.findAllByLecture(it).size
+                else
+                    0
+                LectureResponse.of(it,headCount)
             }
         )
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -4,10 +4,10 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import team.msg.common.enum.ApproveStatus
+import team.msg.common.enums.ApproveStatus
 import team.msg.common.util.UserUtil
-import team.msg.domain.lecture.enum.LectureStatus
-import team.msg.domain.lecture.enum.LectureType
+import team.msg.domain.lecture.enums.LectureStatus
+import team.msg.domain.lecture.enums.LectureType
 import team.msg.domain.lecture.exception.AlreadyApprovedLectureException
 import team.msg.domain.lecture.exception.AlreadySignedUpLectureException
 import team.msg.domain.lecture.exception.InvalidLectureTypeException

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -89,7 +89,7 @@ class LectureServiceImpl(
         val response = AllLecturesResponse(
             lectures.map {
                 val headCount = if(it.approveStatus == ApproveStatus.APPROVED)
-                    registeredLectureRepository.findAllByLecture(it).size
+                    registeredLectureRepository.countByLecture(it)
                 else
                     0
                 LectureResponse.of(it,headCount)
@@ -108,7 +108,7 @@ class LectureServiceImpl(
     override fun queryLectureDetails(id: UUID): LectureDetailsResponse {
         val lecture = queryLecture(id)
 
-        val headCount = registeredLectureRepository.findAllByLecture(lecture).size
+        val headCount = registeredLectureRepository.countByLecture(lecture)
 
         val response = LectureResponse.detailOf(lecture, headCount)
 
@@ -137,7 +137,7 @@ class LectureServiceImpl(
         if(registeredLectureRepository.existsByStudentAndLecture(student, lecture))
             throw AlreadySignedUpLectureException("이미 신청한 강의입니다. info : [ lectureId = ${lecture.id}, studentId = ${student.id} ]")
 
-        val currentSignUpLectureStudent = registeredLectureRepository.findAllByLecture(lecture).size
+        val currentSignUpLectureStudent = registeredLectureRepository.countByLecture(lecture)
 
         if(lecture.maxRegisteredUser <= currentSignUpLectureStudent)
             throw OverMaxRegisteredUserException("수강 인원이 가득 찼습니다. info : [ maxRegisteredUser = ${lecture.maxRegisteredUser}, currentSignUpLectureStudent = $currentSignUpLectureStudent ]")

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/handler/StudentActivityEventHandler.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/handler/StudentActivityEventHandler.kt
@@ -3,7 +3,7 @@ package team.msg.domain.student.handler
 import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
-import team.msg.common.enum.ApproveStatus
+import team.msg.common.enums.ApproveStatus
 import team.msg.domain.student.event.UpdateStudentActivityEvent
 import team.msg.domain.student.model.StudentActivityHistory
 import team.msg.domain.student.repository.StudentActivityHistoryRepository

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentActivityResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentActivityResponse.kt
@@ -1,7 +1,7 @@
 package team.msg.domain.student.presentation.data.response
 
 import org.springframework.data.domain.Page
-import team.msg.common.enum.ApproveStatus
+import team.msg.common.enums.ApproveStatus
 import team.msg.domain.student.model.StudentActivity
 import team.msg.domain.user.model.User
 import java.util.*

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import team.msg.common.enum.ApproveStatus
+import team.msg.common.enums.ApproveStatus
 import team.msg.common.util.UserUtil
 import team.msg.domain.student.event.UpdateStudentActivityEvent
 import team.msg.domain.student.exception.ForbiddenStudentActivityException

--- a/bitgouel-api/src/main/kotlin/team/msg/global/config/QueryDslConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/config/QueryDslConfig.kt
@@ -1,0 +1,16 @@
+package team.msg.global.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QueryDslConfig {
+    @PersistenceContext
+    private lateinit var entityManager: EntityManager
+
+    @Bean
+    fun jpaQueryFactory() = JPAQueryFactory(entityManager)
+}

--- a/bitgouel-domain/build.gradle.kts
+++ b/bitgouel-domain/build.gradle.kts
@@ -13,6 +13,9 @@ bootJar.enabled = false
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis:2.7.5")
+
+    implementation("com.querydsl:querydsl-jpa:5.0.0")
+    kapt("com.querydsl:querydsl-apt:5.0.0:jpa")
 }
 
 allOpen {

--- a/bitgouel-domain/src/main/kotlin/team/msg/common/enums/ApproveStatus.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/common/enums/ApproveStatus.kt
@@ -1,4 +1,4 @@
-package team.msg.common.enum
+package team.msg.common.enums
 
 /**
  * PENDING - 승인 대기중

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/enums/LectureStatus.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/enums/LectureStatus.kt
@@ -1,4 +1,4 @@
-package team.msg.domain.lecture.enum
+package team.msg.domain.lecture.enums
 
 enum class LectureStatus {
     OPEN, CLOSE

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/enums/LectureType.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/enums/LectureType.kt
@@ -1,4 +1,4 @@
-package team.msg.domain.lecture.enum
+package team.msg.domain.lecture.enums
 
 /**
  * MUTUAL_CREDIT_RECOGNITION_PROGRAM - 상호학점인정교육과정

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/Lecture.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/Lecture.kt
@@ -8,9 +8,9 @@ import javax.persistence.FetchType
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import team.msg.common.entity.BaseUUIDEntity
-import team.msg.common.enum.ApproveStatus
-import team.msg.domain.lecture.enum.LectureStatus
-import team.msg.domain.lecture.enum.LectureType
+import team.msg.common.enums.ApproveStatus
+import team.msg.domain.lecture.enums.LectureStatus
+import team.msg.domain.lecture.enums.LectureType
 import team.msg.domain.user.model.User
 import java.time.LocalDateTime
 import java.util.UUID

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/LectureRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/LectureRepository.kt
@@ -6,8 +6,8 @@ import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
-import team.msg.common.enum.ApproveStatus
-import team.msg.domain.lecture.enum.LectureType
+import team.msg.common.enums.ApproveStatus
+import team.msg.domain.lecture.enums.LectureType
 import team.msg.domain.lecture.model.Lecture
 import java.util.*
 

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/LectureRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/LectureRepository.kt
@@ -1,21 +1,9 @@
 package team.msg.domain.lecture.repository
 
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
-import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
-import team.msg.common.enums.ApproveStatus
-import team.msg.domain.lecture.enums.LectureType
 import team.msg.domain.lecture.model.Lecture
+import team.msg.domain.lecture.repository.custom.LectureRepositoryCustom
 import java.util.*
 
 
-interface LectureRepository : JpaRepository<Lecture, UUID> {
-    @EntityGraph(attributePaths = ["user"])
-    @Query("SELECT l FROM Lecture l " +
-            "WHERE (:approve_status is null or l.approveStatus = :approve_status) " +
-            "AND (:lecture_type is null or l.lectureType = :lecture_type)")
-    fun findAllByApproveStatusAndLectureType(pageable: Pageable, @Param("approve_status") approveStatus: ApproveStatus?, @Param("lecture_type") lectureType: LectureType?): Page<Lecture>
-}
+interface LectureRepository : JpaRepository<Lecture, UUID>, LectureRepositoryCustom

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/RegisteredLectureRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/RegisteredLectureRepository.kt
@@ -8,6 +8,6 @@ import java.util.UUID
 
 interface RegisteredLectureRepository : CrudRepository<RegisteredLecture,UUID> {
     fun findAllByStudent(student: Student): List<RegisteredLecture>
-    fun findAllByLecture(lecture: Lecture): List<RegisteredLecture>
     fun existsByStudentAndLecture(student: Student, lecture: Lecture): Boolean
+    fun countByLecture(lecture: Lecture): Int
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/LectureRepositoryCustom.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/LectureRepositoryCustom.kt
@@ -1,0 +1,11 @@
+package team.msg.domain.lecture.repository.custom
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import team.msg.common.enums.ApproveStatus
+import team.msg.domain.lecture.enums.LectureType
+import team.msg.domain.lecture.model.Lecture
+
+interface LectureRepositoryCustom {
+    fun findAllByApproveStatusAndLectureType(pageable: Pageable, approveStatus: ApproveStatus?, lectureType: LectureType?): Page<Lecture>
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/LectureRepositoryCustomImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/LectureRepositoryCustomImpl.kt
@@ -10,6 +10,7 @@ import team.msg.common.enums.ApproveStatus
 import team.msg.domain.lecture.enums.LectureType
 import team.msg.domain.lecture.model.Lecture
 import team.msg.domain.lecture.model.QLecture.lecture
+import team.msg.domain.user.model.QUser.user
 
 @Component
 class LectureRepositoryCustomImpl(
@@ -18,6 +19,8 @@ class LectureRepositoryCustomImpl(
     override fun findAllByApproveStatusAndLectureType(pageable: Pageable, approveStatus: ApproveStatus?, lectureType: LectureType?): Page<Lecture> {
         val response = queryFactory
             .selectFrom(lecture)
+            .leftJoin(lecture.user, user)
+            .fetchJoin()
             .where(
                 eqLectureType(lectureType),
                 eqApproveStatus(approveStatus)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/LectureRepositoryCustomImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/LectureRepositoryCustomImpl.kt
@@ -1,0 +1,41 @@
+package team.msg.domain.lecture.repository.custom
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Component
+import team.msg.common.enums.ApproveStatus
+import team.msg.domain.lecture.enums.LectureType
+import team.msg.domain.lecture.model.Lecture
+import team.msg.domain.lecture.model.QLecture.lecture
+
+@Component
+class LectureRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory
+) : LectureRepositoryCustom {
+    override fun findAllByApproveStatusAndLectureType(pageable: Pageable, approveStatus: ApproveStatus?, lectureType: LectureType?): Page<Lecture> {
+        val response = queryFactory
+            .selectFrom(lecture)
+            .where(
+                eqLectureType(lectureType),
+                eqApproveStatus(approveStatus)
+            )
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .fetch()
+
+        return PageImpl(response)
+    }
+
+    private fun eqLectureType(lectureType: LectureType?): BooleanExpression? {
+        lectureType ?: return null
+        return lecture.lectureType.eq(lectureType)
+    }
+
+    private fun eqApproveStatus(approveStatus: ApproveStatus?): BooleanExpression? {
+        approveStatus ?: return null
+        return lecture.approveStatus.eq(approveStatus)
+    }
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/LectureRepositoryCustomImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/LectureRepositoryCustomImpl.kt
@@ -9,6 +9,7 @@ import team.msg.common.enums.ApproveStatus
 import team.msg.domain.lecture.enums.LectureType
 import team.msg.domain.lecture.model.QLecture.lecture
 import team.msg.domain.user.model.QUser.user
+import java.util.Objects.isNull
 
 @Component
 class LectureRepositoryCustomImpl(
@@ -27,13 +28,9 @@ class LectureRepositoryCustomImpl(
             .limit(pageable.pageSize.toLong())
             .fetch())
 
-    private fun eqLectureType(lectureType: LectureType?): BooleanExpression? {
-        lectureType ?: return null
-        return lecture.lectureType.eq(lectureType)
-    }
+    private fun eqLectureType(lectureType: LectureType?): BooleanExpression? =
+        if(isNull(lectureType)) null else lecture.lectureType.eq(lectureType)
 
-    private fun eqApproveStatus(approveStatus: ApproveStatus?): BooleanExpression? {
-        approveStatus ?: return null
-        return lecture.approveStatus.eq(approveStatus)
-    }
+    private fun eqApproveStatus(approveStatus: ApproveStatus?): BooleanExpression? =
+        if(isNull(approveStatus)) null else lecture.approveStatus.eq(approveStatus)
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/LectureRepositoryCustomImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/LectureRepositoryCustomImpl.kt
@@ -2,13 +2,11 @@ package team.msg.domain.lecture.repository.custom
 
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 import team.msg.common.enums.ApproveStatus
 import team.msg.domain.lecture.enums.LectureType
-import team.msg.domain.lecture.model.Lecture
 import team.msg.domain.lecture.model.QLecture.lecture
 import team.msg.domain.user.model.QUser.user
 
@@ -16,8 +14,8 @@ import team.msg.domain.user.model.QUser.user
 class LectureRepositoryCustomImpl(
     private val queryFactory: JPAQueryFactory
 ) : LectureRepositoryCustom {
-    override fun findAllByApproveStatusAndLectureType(pageable: Pageable, approveStatus: ApproveStatus?, lectureType: LectureType?): Page<Lecture> {
-        val response = queryFactory
+    override fun findAllByApproveStatusAndLectureType(pageable: Pageable, approveStatus: ApproveStatus?, lectureType: LectureType?) = PageImpl(
+        queryFactory
             .selectFrom(lecture)
             .leftJoin(lecture.user, user)
             .fetchJoin()
@@ -27,10 +25,7 @@ class LectureRepositoryCustomImpl(
             )
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
-            .fetch()
-
-        return PageImpl(response)
-    }
+            .fetch())
 
     private fun eqLectureType(lectureType: LectureType?): BooleanExpression? {
         lectureType ?: return null

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivity.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivity.kt
@@ -1,7 +1,7 @@
 package team.msg.domain.student.model
 
 import team.msg.common.entity.BaseUUIDEntity
-import team.msg.common.enum.ApproveStatus
+import team.msg.common.enums.ApproveStatus
 import team.msg.domain.teacher.model.Teacher
 import java.time.LocalDateTime
 import java.util.*

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivityHistory.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivityHistory.kt
@@ -1,7 +1,7 @@
 package team.msg.domain.student.model
 
 import team.msg.common.entity.BaseUUIDEntity
-import team.msg.common.enum.ApproveStatus
+import team.msg.common.enums.ApproveStatus
 import team.msg.domain.teacher.model.Teacher
 import java.time.LocalDateTime
 import java.util.*

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/model/User.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/model/User.kt
@@ -5,7 +5,7 @@ import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
-import team.msg.common.enum.ApproveStatus
+import team.msg.common.enums.ApproveStatus
 import team.msg.domain.user.enums.Authority
 import java.util.*
 


### PR DESCRIPTION
## 💡 개요
querydsl 세팅과 lecture list 필터 작업을 리팩토링했습니다.

## 📃 작업내용
- querydsl을 세팅했습니다.
  - querydsl config를 작성했습니다.

- lecture repository custom을 작성했습니다.

## 🔀 변경사항

- lecture list를 조회하는 과정에서 pending상태의 강의를 조회할 때 수강신청인원을 registered lecture repo를 통해 조회하는 과정을 생략하였습니다.
- 패키지명을 enum에서 enums로 변경했습니다.

## 🍴 사용방법

  - bitgouel-domain의 build.gradle.kts를 빌드해주면 QClass가 생성됩니다.

  - ![image](https://github.com/GSM-MSG/Bitgouel-Server/assets/106813267/f407aeca-6be0-4c50-9fad-b85aab2008fa)
