### PR TITLE
#104 동아리 상세 조회 API 개발

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
@@ -3,10 +3,12 @@ package team.msg.domain.club.presentation
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.msg.domain.club.presentation.data.response.AllClubResponse
+import team.msg.domain.club.presentation.data.response.ClubDetailsResponse
 import team.msg.domain.club.service.ClubService
 import team.msg.domain.school.enums.HighSchool
 
@@ -18,6 +20,12 @@ class ClubController(
     @GetMapping
     fun queryAllClubs(@RequestParam("highSchool") highSchool: HighSchool): ResponseEntity<AllClubResponse> {
         val response = clubService.queryAllClubsService(highSchool)
+        return ResponseEntity.status(HttpStatus.OK).body(response)
+    }
+
+    @GetMapping("/id")
+    fun queryClubDetails(@PathVariable id: Long): ResponseEntity<ClubDetailsResponse> {
+        val response = clubService.queryClubDetailsService(id)
         return ResponseEntity.status(HttpStatus.OK).body(response)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
@@ -23,7 +23,7 @@ class ClubController(
         return ResponseEntity.status(HttpStatus.OK).body(response)
     }
 
-    @GetMapping("/id")
+    @GetMapping("/{id}")
     fun queryClubDetails(@PathVariable id: Long): ResponseEntity<ClubDetailsResponse> {
         val response = clubService.queryClubDetailsService(id)
         return ResponseEntity.status(HttpStatus.OK).body(response)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
@@ -15,10 +15,10 @@ data class ClubResponse(
             )
         }
 
-        fun detailOf(club: Club, highSchool: HighSchool, studentHeadCount: Int) = ClubDetailsResponse(
+        fun detailOf(club: Club,highSchool: HighSchool,headCount: Int) = ClubDetailsResponse(
                 clubName = club.name,
                 highSchoolName = highSchool.schoolName,
-                headCount = studentHeadCount
+                headCount = headCount
             )
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
@@ -15,10 +15,10 @@ data class ClubResponse(
             )
         }
 
-        fun detailOf(club: Club, highSchool: HighSchool, headCount: Int) = ClubDetailsResponse(
+        fun detailOf(club: Club, highSchool: HighSchool, studentHeadCount: Int) = ClubDetailsResponse(
                 clubName = club.name,
                 highSchoolName = highSchool.schoolName,
-                headCount = headCount
+                headCount = studentHeadCount
             )
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
@@ -1,6 +1,7 @@
 package team.msg.domain.club.presentation.data.response
 
 import team.msg.domain.club.model.Club
+import team.msg.domain.school.enums.HighSchool
 
 data class ClubResponse(
     val id: Long,
@@ -13,9 +14,21 @@ data class ClubResponse(
                 name = it.name
             )
         }
+
+        fun detailOf(club: Club, highSchool: HighSchool, headCount: Int) = ClubDetailsResponse(
+                clubName = club.name,
+                highSchoolName = highSchool.schoolName,
+                headCount = headCount
+            )
     }
 }
 
 data class AllClubResponse(
     val club: List<ClubResponse>
+)
+
+data class ClubDetailsResponse(
+    val clubName: String,
+    val highSchoolName: String,
+    val headCount: Int
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
@@ -15,11 +15,11 @@ data class ClubResponse(
             )
         }
 
-        fun detailOf(club: Club,highSchool: HighSchool,headCount: Int) = ClubDetailsResponse(
-                clubName = club.name,
-                highSchoolName = highSchool.schoolName,
-                headCount = headCount
-            )
+        fun detailOf(club: Club, highSchool: HighSchool, headCount: Int) = ClubDetailsResponse(
+            clubName = club.name,
+            highSchoolName = highSchool.schoolName,
+            headCount = headCount
+        )
     }
 }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
@@ -1,9 +1,10 @@
 package team.msg.domain.club.service
 
 import team.msg.domain.club.presentation.data.response.AllClubResponse
+import team.msg.domain.club.presentation.data.response.ClubDetailsResponse
 import team.msg.domain.school.enums.HighSchool
 
 interface ClubService {
     fun queryAllClubsService(highSchool: HighSchool): AllClubResponse
-    fun queryClubDetailsService(id: Long)
+    fun queryClubDetailsService(id: Long): ClubDetailsResponse
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
@@ -5,4 +5,5 @@ import team.msg.domain.school.enums.HighSchool
 
 interface ClubService {
     fun queryAllClubsService(highSchool: HighSchool): AllClubResponse
+    fun queryClubDetailsService(id: Long)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
@@ -10,10 +10,8 @@ import team.msg.domain.club.presentation.data.response.ClubResponse
 import team.msg.domain.club.repository.ClubRepository
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.school.exception.SchoolNotFoundException
-import team.msg.domain.school.model.School
 import team.msg.domain.school.repository.SchoolRepository
 import team.msg.domain.student.repository.StudentRepository
-import team.msg.domain.user.repository.UserRepository
 
 @Service
 class ClubServiceImpl(

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
@@ -24,7 +24,7 @@ class ClubServiceImpl(
      * 모든 동아리를 조회하는 비즈니스 로직
      * @param 동아리를 조회하기 위한 학교 이름
      */
-    @Transactional(readOnly = true, rollbackFor = [Exception::class])
+    @Transactional(readOnly = true)
     override fun queryAllClubsService(highSchool: HighSchool): AllClubResponse {
         val school = schoolRepository.findByHighSchool(highSchool)
             ?: throw SchoolNotFoundException("존재하지 않는 학교 입니다. info : [ highSchool = $highSchool ]")
@@ -42,13 +42,14 @@ class ClubServiceImpl(
      * 동아리를 상세 조회하는 비즈니스 로직
      * @param 동아리를 상세 조회하기 위한 id
      */
+    @Transactional(readOnly = true)
     override fun queryClubDetailsService(id: Long): ClubDetailsResponse {
         val club = clubRepository.findByIdOrNull(id)
             ?: throw ClubNotFoundException("존재하지 않는 동아리 입니다. info : [ clubId = $id ]")
 
-        val studentHeadCount = studentRepository.countByClub(club).toInt()
+        val headCount = studentRepository.countByClub(club).toInt()
 
-        val response = ClubResponse.detailOf(club, club.school.highSchool, studentHeadCount)
+        val response = ClubResponse.detailOf(club, club.school.highSchool, headCount)
 
         return response
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
@@ -1,18 +1,22 @@
 package team.msg.domain.club.service
 
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.msg.domain.club.exception.ClubNotFoundException
 import team.msg.domain.club.presentation.data.response.AllClubResponse
 import team.msg.domain.club.presentation.data.response.ClubResponse
 import team.msg.domain.club.repository.ClubRepository
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.school.exception.SchoolNotFoundException
+import team.msg.domain.school.model.School
 import team.msg.domain.school.repository.SchoolRepository
 
 @Service
 class ClubServiceImpl(
     private val clubRepository: ClubRepository,
-    private val schoolRepository: SchoolRepository
+    private val schoolRepository: SchoolRepository,
+
 ) : ClubService {
 
     /**
@@ -31,5 +35,18 @@ class ClubServiceImpl(
         )
 
         return response
+    }
+
+    /**
+     * 동아리를 상세 조회하는 비즈니스 로직
+     * @param 동아리를 상세 조회하기 위한 id
+     */
+    override fun queryClubDetailsService(id: Long) {
+        val club = clubRepository.findByIdOrNull(id)
+            ?: throw ClubNotFoundException("존재하지 않는 동아리 입니다. info : [ clubId = $id ]")
+
+
+
+        val response = ClubResponse.detailOf(club, club.school.highSchool,)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
@@ -5,18 +5,21 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.msg.domain.club.exception.ClubNotFoundException
 import team.msg.domain.club.presentation.data.response.AllClubResponse
+import team.msg.domain.club.presentation.data.response.ClubDetailsResponse
 import team.msg.domain.club.presentation.data.response.ClubResponse
 import team.msg.domain.club.repository.ClubRepository
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.school.exception.SchoolNotFoundException
 import team.msg.domain.school.model.School
 import team.msg.domain.school.repository.SchoolRepository
+import team.msg.domain.student.repository.StudentRepository
+import team.msg.domain.user.repository.UserRepository
 
 @Service
 class ClubServiceImpl(
     private val clubRepository: ClubRepository,
     private val schoolRepository: SchoolRepository,
-
+    private val studentRepository: StudentRepository
 ) : ClubService {
 
     /**
@@ -41,12 +44,14 @@ class ClubServiceImpl(
      * 동아리를 상세 조회하는 비즈니스 로직
      * @param 동아리를 상세 조회하기 위한 id
      */
-    override fun queryClubDetailsService(id: Long) {
+    override fun queryClubDetailsService(id: Long): ClubDetailsResponse {
         val club = clubRepository.findByIdOrNull(id)
             ?: throw ClubNotFoundException("존재하지 않는 동아리 입니다. info : [ clubId = $id ]")
 
+        val studentHeadCount = studentRepository.countByClub(club).toInt()
 
+        val response = ClubResponse.detailOf(club, club.school.highSchool, studentHeadCount)
 
-        val response = ClubResponse.detailOf(club, club.school.highSchool,)
+        return response
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -61,7 +61,7 @@ class SecurityConfig(
 
             // club
             .mvcMatchers(HttpMethod.GET, "/club").hasRole(ADMIN)
-            .mvcMatchers(HttpMethod.GET, "/club/{id}").hasAnyRole(STUDENT, ADMIN)
+            .mvcMatchers(HttpMethod.GET, "/club/{id}").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
 
             // activity
             .mvcMatchers(HttpMethod.POST, "/activity").hasRole(STUDENT)

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -61,6 +61,7 @@ class SecurityConfig(
 
             // club
             .mvcMatchers(HttpMethod.GET, "/club").hasRole(ADMIN)
+            .mvcMatchers(HttpMethod.GET, "/club/{id}").hasAnyRole(STUDENT, ADMIN)
 
             // activity
             .mvcMatchers(HttpMethod.POST, "/activity").hasRole(STUDENT)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/StudentRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/StudentRepository.kt
@@ -2,6 +2,7 @@ package team.msg.domain.student.repository
 
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
+import team.msg.domain.club.model.Club
 import team.msg.domain.student.model.Student
 import team.msg.domain.user.model.User
 import java.util.*
@@ -10,4 +11,5 @@ interface StudentRepository : CrudRepository<Student, UUID> {
     fun findByUser(user: User): Student?
     @Query("SELECT student FROM Student student JOIN FETCH student.user WHERE student.id = :id")
     fun findStudentById(id: UUID): Student?
+    fun countByClub(club: Club): Long
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/teacher/model/Teacher.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/teacher/model/Teacher.kt
@@ -1,15 +1,14 @@
 package team.msg.domain.teacher.model
 
-import team.msg.common.entity.BaseUUIDEntity
 import javax.persistence.CascadeType
 import javax.persistence.Entity
 import javax.persistence.FetchType
 import javax.persistence.JoinColumn
-import javax.persistence.ManyToOne
 import javax.persistence.OneToOne
+import team.msg.common.entity.BaseUUIDEntity
 import team.msg.domain.club.model.Club
 import team.msg.domain.user.model.User
-import java.util.UUID
+import java.util.*
 
 @Entity
 class Teacher(
@@ -21,7 +20,7 @@ class Teacher(
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "club_id", nullable = false)
     val club: Club
 


### PR DESCRIPTION
## 💡 개요
동아리 상세 조회 API 개발
## 📃 작업내용
Teacher 와 Club 의 연관관계를 1:1 로 변경해주었습니다.
count jpa method 를 사용해 동아리에 속한 학생 수를 구했습니다.
