### PR TITLE
#119 DataInitializer 데이터 존재 여부 count 쿼리 성능 개선

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/common/init/DataInitializer.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/common/init/DataInitializer.kt
@@ -41,17 +41,17 @@ class DataInitializer(
 
     /**
      * ApplicationReadyEvent가 발행되면 initData가 실행됩니다.
-     * school, club의 데이터 count가 0이라면 데이터 삽입이 실행됩니다.
+     * school, club id = 1인 엔티티가 존재하면 Data Init을 실행하지 않는다.
      */
     @EventListener(ApplicationReadyEvent::class)
     @Transactional
     fun initData() {
-        if(schoolRepository.count() == 0L) {
+        if(schoolRepository.existsOne(1)) {
             log.info("=== RUN Init School Data ===")
             initSchool()
         }
 
-        if(clubRepository.count() == 0L) {
+        if(clubRepository.existsOne(1)) {
             log.info("=== RUN Init Club Data ===")
             initClub()
         }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/ClubRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/ClubRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Query
 import team.msg.domain.club.model.Club
 import team.msg.domain.school.model.School
 
-interface ClubRepository : JpaRepository<Club, Long> {
+interface ClubRepository : JpaRepository<Club, Long>, CustomClubRepository {
     @EntityGraph(attributePaths = ["school"], type = EntityGraph.EntityGraphType.FETCH)
     fun findByNameAndSchool(name: String, school: School): Club?
 

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/CustomClubRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/CustomClubRepository.kt
@@ -1,0 +1,5 @@
+package team.msg.domain.club.repository
+
+interface CustomClubRepository {
+    fun existsOne(id: Long): Boolean
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/CustomClubRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/club/repository/CustomClubRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package team.msg.domain.club.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import team.msg.domain.club.model.QClub.club
+
+class CustomClubRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : CustomClubRepository {
+
+    override fun existsOne(id: Long): Boolean {
+        val fetchOne = queryFactory.selectOne()
+            .from(club)
+            .where(club.id.eq(id))
+            .fetchFirst() // limit 1
+
+        return fetchOne != null
+    }
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/school/repository/CustomSchoolRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/school/repository/CustomSchoolRepository.kt
@@ -1,0 +1,5 @@
+package team.msg.domain.school.repository
+
+interface CustomSchoolRepository {
+    fun existsOne(id: Long): Boolean
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/school/repository/CustomSchoolRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/school/repository/CustomSchoolRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package team.msg.domain.school.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import team.msg.domain.school.model.QSchool.school
+
+class CustomSchoolRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : CustomSchoolRepository {
+
+    override fun existsOne(id: Long): Boolean {
+        val fetchOne = queryFactory.selectOne()
+            .from(school)
+            .where(school.id.eq(id))
+            .fetchFirst() // limit 1
+
+        return fetchOne != null
+    }
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/school/repository/SchoolRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/school/repository/SchoolRepository.kt
@@ -4,6 +4,6 @@ import org.springframework.data.repository.CrudRepository
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.school.model.School
 
-interface SchoolRepository : CrudRepository<School, Long> {
+interface SchoolRepository : CrudRepository<School, Long>, CustomSchoolRepository {
     fun findByHighSchool(highSchool: HighSchool): School?
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 BUILD_JAR=$(ls /home/ec2-user/Bitgouel-Server/bitgouel-api/build/libs/*.jar)
 JAR_NAME=$(basename $BUILD_JAR)
-echo "> build 파일명: $JAR_NAME" >> /home/ec2-user/action/deploy.log
+echo "> build 파일명: $JAR_NAME" >> /home/ec2-user/deploy.log
 
-echo "> build 파일 복사" >> /home/ec2-user/action/deploy.log
-DEPLOY_PATH=/home/ec2-user/action/
+echo "> build 파일 복사" >> /home/ec2-user/deploy.log
+DEPLOY_PATH=/home/ec2-user/
 cp $BUILD_JAR $DEPLOY_PATH
 
-echo "> 현재 실행중인 애플리케이션 pid 확인" >> /home/ec2-user/action/deploy.log
+echo "> 현재 실행중인 애플리케이션 pid 확인" >> /home/ec2-user/deploy.log
 CURRENT_PID=$(pgrep -f $JAR_NAME)
 
 if [ -z $CURRENT_PID ]
 then
-  echo "> 현재 구동중인 애플리케이션이 없으므로 종료하지 않습니다." >> /home/ec2-user/action/deploy.log
+  echo "> 현재 구동중인 애플리케이션이 없으므로 종료하지 않습니다." >> /home/ec2-user/deploy.log
 else
   echo "> kill -15 $CURRENT_PID"
   kill -15 $CURRENT_PID
@@ -20,5 +20,5 @@ else
 fi
 
 DEPLOY_JAR=$DEPLOY_PATH$JAR_NAME
-echo "> DEPLOY_JAR 배포"    >> /home/ec2-user/action/deploy.log
+echo "> DEPLOY_JAR 배포"    >> /home/ec2-user/deploy.log
 nohup java -jar $DEPLOY_JAR --logging.file.path=/home/ec2-user/ --logging.level.org.hibernate.SQL=DEBUG >> /home/ec2-user/deploy.log 2>/home/ec2-user/deploy_err.log &


### PR DESCRIPTION
## 💡 개요
DataInitializer 데이터 존재 여부 count 쿼리 성능을 개선했습니다.

## 📃 작업내용
ClubRepository `exsitsOne`: Club 데이터가 한 개 존재하는지 검증하는 로직
SchoolRepository `exsitsOne`: School 데이터가 한 개 존재하는지 검증하는 로직

DataInitializer가 실행이 된 어플리케이션이라면 id가 1인 School Club 엔티티가 존재합니다.
1인 엔티티가 존재하는지에 대한 여부에 따라서 data init 작업을 실행할지 검증합니다.

원래는 `count() == 0` 일때 실행했지만 이렇게된다면 데이터를 전부 count 하는 불필요한 연산이 발생됩니다.
관련 이슈를 해결하는 솔루션으로 이 방법을 채택했습니다.

## 🔀 변경사항
**CustomClub, School Repository**

## 🎸 기타
exists 관련한 로직이 필요하다면 이러한 로직을 사용해보는 것도 추천드립니다.