### PR TITLE
StudentActivity 검증 id 비교에서 동등비교로 수정합니다. + find infix 함수 적용

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/common/aop/log/HttpLoggingAspect.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/common/aop/log/HttpLoggingAspect.kt
@@ -1,4 +1,4 @@
-package team.msg.common.aop
+package team.msg.common.aop.log
 
 import org.aspectj.lang.JoinPoint
 import org.aspectj.lang.ProceedingJoinPoint

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -114,7 +114,7 @@ class StudentActivityServiceImpl(
         val studentActivity = studentActivityRepository.findByIdOrNull(id)
             ?: throw StudentActivityNotFoundException("학생 활동을 찾을 수 없습니다. info : [ studentActivityId = $id ]")
 
-        if(student.id != studentActivity.student.id)
+        if(student != studentActivity.student)
             throw ForbiddenStudentActivityException("해당 학생 활동에 대한 권한이 없습니다. info : [ studentId = ${student.id} ]")
 
         studentActivityRepository.delete(studentActivity)
@@ -134,7 +134,7 @@ class StudentActivityServiceImpl(
         val studentActivity = studentActivityRepository.findByIdOrNull(id)
             ?: throw StudentActivityNotFoundException("학생 활동을 찾을 수 없습니다. info : [ studentActivityId = $id ]")
 
-        if(teacher.id != studentActivity.teacher.id)
+        if(teacher != studentActivity.teacher)
             throw ForbiddenStudentActivityException("해당 학생 활동에 대한 권한이 없습니다. info : [ teacherId = ${teacher.id} ]")
 
         studentActivityRepository.delete(studentActivity)
@@ -154,7 +154,7 @@ class StudentActivityServiceImpl(
         val studentActivity = studentActivityRepository.findByIdOrNull(id)
             ?: throw StudentActivityNotFoundException("학생 활동을 찾을 수 없습니다. info : [ studentActivityId = $id ]")
 
-        if(teacher.id != studentActivity.teacher.id)
+        if(teacher != studentActivity.teacher)
             throw ForbiddenStudentActivityException("해당 학생 활동에 대한 권한이 없습니다. info : [ teacherId = ${teacher.id} ]")
 
         val updatedStudentActivity = StudentActivity(

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional
 import team.msg.common.enums.ApproveStatus
 import team.msg.common.util.UserUtil
 import team.msg.domain.bbozzak.model.Bbozzak
+import team.msg.domain.club.model.Club
 import team.msg.domain.company.model.CompanyInstructor
 import team.msg.domain.government.model.Government
 import team.msg.domain.professor.model.Professor
@@ -28,6 +29,7 @@ import team.msg.domain.student.repository.StudentRepository
 import team.msg.domain.teacher.exception.TeacherNotFoundException
 import team.msg.domain.teacher.model.Teacher
 import team.msg.domain.teacher.repository.TeacherRepository
+import team.msg.domain.user.model.User
 import java.util.*
 
 @Service
@@ -47,11 +49,9 @@ class StudentActivityServiceImpl(
     override fun createStudentActivity(request: CreateStudentActivityRequest) {
         val user = userUtil.queryCurrentUser()
 
-        val student = studentRepository.findByUser(user)
-            ?: throw StudentNotFoundException("학생을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+        val student = studentRepository findByUser user
 
-        val teacher = teacherRepository.findByClub(student.club)
-            ?: throw TeacherNotFoundException("취업 동아리 선생님을 찾을 수 없습니다.")
+        val teacher = teacherRepository findByClub student.club
 
         val studentActivity = StudentActivity(
             id = UUID.randomUUID(),
@@ -77,11 +77,9 @@ class StudentActivityServiceImpl(
     override fun updateStudentActivity(id: UUID, request: UpdateStudentActivityRequest) {
         val user = userUtil.queryCurrentUser()
 
-        val student = studentRepository.findByUser(user)
-            ?: throw StudentNotFoundException("학생을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+        val student = studentRepository findByUser user
 
-        val studentActivity = studentActivityRepository.findByIdOrNull(id)
-            ?: throw StudentActivityNotFoundException("학생 활동을 찾을 수 없습니다. info : [ studentActivityId = $id ]")
+        val studentActivity = studentActivityRepository findById id
 
         if(student.id != studentActivity.student.id)
             throw ForbiddenStudentActivityException("해당 학생 활동에 대한 권한이 없습니다. info : [ studentId = ${student.id} ]")
@@ -108,11 +106,9 @@ class StudentActivityServiceImpl(
     override fun deleteStudentActivity(id: UUID) {
         val user = userUtil.queryCurrentUser()
 
-        val student = studentRepository.findByUser(user)
-            ?: throw StudentNotFoundException("학생을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+        val student = studentRepository findByUser user
 
-        val studentActivity = studentActivityRepository.findByIdOrNull(id)
-            ?: throw StudentActivityNotFoundException("학생 활동을 찾을 수 없습니다. info : [ studentActivityId = $id ]")
+        val studentActivity = studentActivityRepository findById id
 
         if(student != studentActivity.student)
             throw ForbiddenStudentActivityException("해당 학생 활동에 대한 권한이 없습니다. info : [ studentId = ${student.id} ]")
@@ -128,11 +124,9 @@ class StudentActivityServiceImpl(
     override fun rejectStudentActivity(id: UUID) {
         val user = userUtil.queryCurrentUser()
 
-        val teacher = teacherRepository.findByUser(user)
-            ?: throw TeacherNotFoundException("취업 동아리 선생님을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+        val teacher = teacherRepository findByUser user
 
-        val studentActivity = studentActivityRepository.findByIdOrNull(id)
-            ?: throw StudentActivityNotFoundException("학생 활동을 찾을 수 없습니다. info : [ studentActivityId = $id ]")
+        val studentActivity = studentActivityRepository findById id
 
         if(teacher != studentActivity.teacher)
             throw ForbiddenStudentActivityException("해당 학생 활동에 대한 권한이 없습니다. info : [ teacherId = ${teacher.id} ]")
@@ -148,11 +142,9 @@ class StudentActivityServiceImpl(
     override fun approveStudentActivity(id: UUID) {
         val user = userUtil.queryCurrentUser()
 
-        val teacher = teacherRepository.findByUser(user)
-            ?: throw TeacherNotFoundException("취업 동아리 선생님을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+        val teacher = teacherRepository findByUser user
 
-        val studentActivity = studentActivityRepository.findByIdOrNull(id)
-            ?: throw StudentActivityNotFoundException("학생 활동을 찾을 수 없습니다. info : [ studentActivityId = $id ]")
+        val studentActivity = studentActivityRepository findById id
 
         if(teacher != studentActivity.teacher)
             throw ForbiddenStudentActivityException("해당 학생 활동에 대한 권한이 없습니다. info : [ teacherId = ${teacher.id} ]")
@@ -196,11 +188,9 @@ class StudentActivityServiceImpl(
     override fun queryStudentActivitiesByStudent(studentId: UUID, pageable: Pageable): StudentActivitiesResponse {
         val user = userUtil.queryCurrentUser()
 
-        val student = studentRepository.findStudentById(studentId)
-            ?: throw StudentNotFoundException("학생을 찾을 수 없습니다. info : [ studentId = $studentId ]")
+        val student = studentRepository findByUser user
 
-        val teacher = teacherRepository.findByUser(user)
-            ?: throw TeacherNotFoundException("취업 동아리 선생님을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+        val teacher = teacherRepository findByUser user
 
         if(student.club != teacher.club)
             throw ForbiddenStudentActivityException("해당 학생 활동에 대한 권한이 없습니다. info : [ teacherId = ${teacher.id} ]")
@@ -222,8 +212,7 @@ class StudentActivityServiceImpl(
     override fun queryMyStudentActivities(pageable: Pageable): StudentActivitiesResponse {
         val user = userUtil.queryCurrentUser()
 
-        val student = studentRepository.findByUser(user)
-            ?: throw StudentNotFoundException("학생을 찾을 수 없습니다. info : [ userId = ${user.id}, username = ${user.name} ]")
+        val student = studentRepository findByUser user
 
         val studentActivities = studentActivityRepository.findAllByStudent(student, pageable)
 
@@ -244,8 +233,7 @@ class StudentActivityServiceImpl(
 
         val entity = userUtil.getAuthorityEntityAndOrganization(user).first
 
-        val studentActivity = studentActivityRepository.findByIdOrNull(id)
-            ?: throw StudentActivityNotFoundException("학생 활동을 찾을 수 없습니다. info : [ studentActivityId = $id ]")
+        val studentActivity = studentActivityRepository findById id
 
         when(entity) {
             is Student -> {
@@ -266,4 +254,20 @@ class StudentActivityServiceImpl(
 
         return response
     }
+
+    /**
+     * find ?: throw 로직을 단순화시킨 infix 함수들입니다.
+     */
+    private infix fun StudentRepository.findByUser(user: User): Student =
+        this.findByUser(user) ?: throw StudentNotFoundException("학생을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+
+    private infix fun StudentActivityRepository.findById(id: UUID): StudentActivity =
+        this.findByIdOrNull(id) ?: throw StudentActivityNotFoundException("학생 활동을 찾을 수 없습니다. info : [ studentActivityId = $id ]")
+
+    private infix fun TeacherRepository.findByUser(user: User): Teacher =
+        this.findByUser(user) ?: throw TeacherNotFoundException("취업 동아리 선생님을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+
+    private infix fun TeacherRepository.findByClub(club: Club): Teacher =
+        this.findByClub(club) ?: throw TeacherNotFoundException("관련 동아리의 취업 동아리 선생님을 찾을 수 없습니다. info : [ clubId = ${club.id} ]")
+
 }


### PR DESCRIPTION
## 💡 개요
AOP를 사용하려 했으나 함수에 대한 제약 조건이 별로 있지 않기 때문에 하지 않았습니다.
StudentAcitivty 부분 검증 로직을 수정합니다.
추가로 infix 함수를 적용해 find is null throw 관련 로직을 단순화 했습니다.
다른 도메인 서비스들도 적용해보면 좋을 것 같습니다.

## 📃 작업내용
- StudentActivity 검증 로직 수정
- StudentActivity find infix 함수 적용

예외를 던지는 로직이 중복되어있기 때문에 함수 분리보단 이렇게 infix 함수로 간결하게 표기할 수 있도록 했습니다.
```kt
     /**
     * find ?: throw 로직을 단순화시킨 infix 함수들입니다.
     */
    private infix fun StudentRepository.findByUser(user: User): Student =
        this.findByUser(user) ?: throw StudentNotFoundException("학생을 찾을 수 없습니다. info : [ userId = ${user.id} ]")

    private infix fun StudentActivityRepository.findById(id: UUID): StudentActivity =
        this.findByIdOrNull(id) ?: throw StudentActivityNotFoundException("학생 활동을 찾을 수 없습니다. info : [ studentActivityId = $id ]")

    private infix fun TeacherRepository.findByUser(user: User): Teacher =
        this.findByUser(user) ?: throw TeacherNotFoundException("취업 동아리 선생님을 찾을 수 없습니다. info : [ userId = ${user.id} ]")

    private infix fun TeacherRepository.findByClub(club: Club): Teacher =
        this.findByClub(club) ?: throw TeacherNotFoundException("관련 동아리의 취업 동아리 선생님을 찾을 수 없습니다. info : [ clubId = ${club.id} ]")

```

정의 하는 부분은 위와 같으며 사용은 다음과 같이 할 수 있습니다.

```kt
 val studentActivity = studentActivityRepository findById id
```

변경사항을 확인해주시고 각 도메인 파트 담당자분들은 적용해주셨으면 좋겠습니다.