### PR TITLE
133 활동 날짜의 데이터 타입을 Date로 변경

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/request/CreateStudentActivityRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/request/CreateStudentActivityRequest.kt
@@ -1,10 +1,10 @@
 package team.msg.domain.student.presentation.data.request
 
-import java.time.LocalDateTime
+import java.time.LocalDate
 
 data class CreateStudentActivityRequest(
     val title: String,
     val content: String,
     val credit: Int,
-    val activityDate: LocalDateTime
+    val activityDate: LocalDate
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/request/UpdateStudentActivityRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/request/UpdateStudentActivityRequest.kt
@@ -1,10 +1,10 @@
 package team.msg.domain.student.presentation.data.request
 
-import java.time.LocalDateTime
+import java.time.LocalDate
 
 data class UpdateStudentActivityRequest(
     val title: String,
     val content: String,
     val credit: Int,
-    val activityDate: LocalDateTime
+    val activityDate: LocalDate
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentActivityResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentActivityResponse.kt
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Page
 import team.msg.common.enums.ApproveStatus
 import team.msg.domain.student.model.StudentActivity
 import team.msg.domain.user.model.User
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
@@ -51,6 +52,6 @@ data class StudentActivityDetailsResponse(
     val title: String,
     val content: String,
     val credit: Int,
-    val activityDate: LocalDateTime,
+    val activityDate: LocalDate,
     val modifiedAt: LocalDateTime
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/web/CreateStudentActivityWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/web/CreateStudentActivityWebRequest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
 import javax.validation.constraints.Size
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class CreateStudentActivityWebRequest(
@@ -19,6 +20,6 @@ data class CreateStudentActivityWebRequest(
     val credit: Int,
 
     @field:NotNull
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    val activityDate: LocalDateTime
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    val activityDate: LocalDate
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/web/UpdateStudentActivityWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/web/UpdateStudentActivityWebRequest.kt
@@ -1,22 +1,25 @@
 package team.msg.domain.student.presentation.data.web
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import javax.validation.constraints.Max
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
-import java.time.LocalDateTime
+import javax.validation.constraints.Size
+import java.time.LocalDate
 
 data class UpdateStudentActivityWebRequest(
     @field:NotBlank
-    @field:Max(100)
+    @field:Size(max = 100)
     val title: String,
 
     @field:NotBlank
-    @field:Max(1000)
+    @field:Size(max = 1000)
     val content: String,
 
     @field:NotNull
     val credit: Int,
 
     @field:NotNull
-    val activityDate: LocalDateTime
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    val activityDate: LocalDate
 )

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivity.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivity.kt
@@ -3,6 +3,7 @@ package team.msg.domain.student.model
 import team.msg.common.entity.BaseUUIDEntity
 import team.msg.common.enums.ApproveStatus
 import team.msg.domain.teacher.model.Teacher
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 import javax.persistence.*
@@ -26,8 +27,8 @@ class StudentActivity(
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
     var approveStatus: ApproveStatus,
 
-    @Column(nullable = false, columnDefinition = "DATETIME(6)")
-    var activityDate: LocalDateTime,
+    @Column(columnDefinition = "DATE", nullable = false)
+    var activityDate: LocalDate,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "student_id", columnDefinition = "BINARY(16)", nullable = false)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivityHistory.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivityHistory.kt
@@ -1,11 +1,17 @@
 package team.msg.domain.student.model
 
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.FetchType
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
 import team.msg.common.entity.BaseUUIDEntity
 import team.msg.common.enums.ApproveStatus
 import team.msg.domain.teacher.model.Teacher
-import java.time.LocalDateTime
+import java.time.LocalDate
 import java.util.*
-import javax.persistence.*
 
 /**
  * StudentActivity의 History를 저장하는 엔티티입니다.
@@ -29,8 +35,8 @@ class StudentActivityHistory(
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
     var approveStatus: ApproveStatus,
 
-    @Column(nullable = false, columnDefinition = "DATETIME(6)")
-    var activityDate: LocalDateTime,
+    @Column(columnDefinition = "DATE", nullable = false)
+    var activityDate: LocalDate,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "student_id", columnDefinition = "BINARY(16)", nullable = false)


### PR DESCRIPTION
## 💡 개요
학생 활동 엔티티의 활동 날짜에 불필요한 시간/분/초까지 들어가 있어 날짜만 저장되게 하였습니다
## 📃 작업내용
StudentActivity Entity activityDate column type DATETIME(6) -> DATE
CreateStudent(Web)Request activityDate 타입 LocalDate로 변경
UpdateStudent(Web)Request activityDate 타입 LocalDate로 변경
StudentActviityDetail Response 타입 변경
