### PR TITLE
# 126 자격증 리스트 조회 학생 API 개발

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/CertificationController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/CertificationController.kt
@@ -3,11 +3,13 @@ package team.msg.domain.certification.presentation
 import javax.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import team.msg.domain.certification.mapper.CertificationRequestMapper
+import team.msg.domain.certification.presentation.data.response.AllCertificationsResponse
 import team.msg.domain.certification.presentation.data.web.CreateCertificationWebRequest
 import team.msg.domain.certification.service.CertificationService
 
@@ -22,5 +24,11 @@ class CertificationController(
         val request = certificationRequestMapper.createCertificationWebRequestToDto(webRequest)
         certificationService.createCertification(request)
         return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @GetMapping
+    fun queryAllCertifications(): ResponseEntity<AllCertificationsResponse> {
+        val response = certificationService.queryAllCertifications()
+        return ResponseEntity.status(HttpStatus.OK).body(response)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/CertificationController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/CertificationController.kt
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import team.msg.domain.certification.mapper.CertificationRequestMapper
-import team.msg.domain.certification.presentation.data.response.AllCertificationsResponse
+import team.msg.domain.certification.presentation.data.response.CertificationsResponse
 import team.msg.domain.certification.presentation.data.web.CreateCertificationWebRequest
 import team.msg.domain.certification.service.CertificationService
 
@@ -27,7 +27,7 @@ class CertificationController(
     }
 
     @GetMapping
-    fun queryAllCertifications(): ResponseEntity<AllCertificationsResponse> {
+    fun queryAllCertifications(): ResponseEntity<CertificationsResponse> {
         val response = certificationService.queryAllCertifications()
         return ResponseEntity.status(HttpStatus.OK).body(response)
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/data/response/CertificationResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/data/response/CertificationResponse.kt
@@ -20,6 +20,6 @@ data class CertificationResponse(
     }
 }
 
-data class AllCertificationsResponse(
+data class CertificationsResponse(
     val certifications: List<CertificationResponse>
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/data/response/CertificationResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/data/response/CertificationResponse.kt
@@ -1,0 +1,25 @@
+package team.msg.domain.certification.presentation.data.response
+
+import team.msg.domain.certifiacation.model.Certification
+import java.time.LocalDate
+import java.util.UUID
+
+data class CertificationResponse(
+    val id: UUID,
+    val name: String,
+    val acquisitionDate: LocalDate
+) {
+    companion object {
+        fun listOf(certifications: List<Certification>) = certifications.map {
+            CertificationResponse(
+                id = it.id,
+                name = it.name,
+                acquisitionDate = it.acquisitionDate
+            )
+        }
+    }
+}
+
+data class AllCertificationsResponse(
+    val certifications: List<CertificationResponse>
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationService.kt
@@ -1,7 +1,9 @@
 package team.msg.domain.certification.service
 
 import team.msg.domain.certification.presentation.data.request.CreateCertificationRequest
+import team.msg.domain.certification.presentation.data.response.AllCertificationsResponse
 
 interface CertificationService {
     fun createCertification(createCertificationRequest: CreateCertificationRequest)
+    fun queryAllCertifications(): AllCertificationsResponse
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationService.kt
@@ -1,9 +1,9 @@
 package team.msg.domain.certification.service
 
 import team.msg.domain.certification.presentation.data.request.CreateCertificationRequest
-import team.msg.domain.certification.presentation.data.response.AllCertificationsResponse
+import team.msg.domain.certification.presentation.data.response.CertificationsResponse
 
 interface CertificationService {
     fun createCertification(createCertificationRequest: CreateCertificationRequest)
-    fun queryAllCertifications(): AllCertificationsResponse
+    fun queryAllCertifications(): CertificationsResponse
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
@@ -6,9 +6,14 @@ import team.msg.common.util.UserUtil
 import team.msg.domain.certifiacation.model.Certification
 import team.msg.domain.certifiacation.repository.CertificationRepository
 import team.msg.domain.certification.presentation.data.request.CreateCertificationRequest
+import team.msg.domain.certification.presentation.data.response.AllCertificationsResponse
+import team.msg.domain.certification.presentation.data.response.CertificationResponse
 import team.msg.domain.student.exception.StudentNotFoundException
 import team.msg.domain.student.model.Student
 import team.msg.domain.student.repository.StudentRepository
+import team.msg.domain.teacher.exception.TeacherNotFoundException
+import team.msg.domain.teacher.repository.TeacherRepository
+import team.msg.domain.user.enums.Authority
 import team.msg.domain.user.model.User
 import java.util.*
 
@@ -16,7 +21,8 @@ import java.util.*
 class CertificationServiceImpl(
     private val certificationRepository: CertificationRepository,
     private val studentRepository: StudentRepository,
-    private val userUtil: UserUtil
+    private val userUtil: UserUtil,
+    private val teacherRepository: TeacherRepository,
 ) : CertificationService {
 
     /**
@@ -36,6 +42,22 @@ class CertificationServiceImpl(
         )
 
         certificationRepository.save(certification)
+    }
+
+    @Transactional(readOnly = true)
+    override fun queryAllCertifications(): AllCertificationsResponse {
+        val user = userUtil.queryCurrentUser()
+
+        val student = studentRepository.findByUser(user)
+            ?: throw StudentNotFoundException("존재하지 않는 학생입니다. info : [ userId = ${user.id} ]")
+
+        val certifications = certificationRepository.findAllByStudentId(student.id)
+
+        val response = AllCertificationsResponse(
+            CertificationResponse.listOf(certifications)
+        )
+
+        return response
     }
 
     private infix fun StudentRepository.findByUer(user: User): Student =

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
@@ -11,9 +11,6 @@ import team.msg.domain.certification.presentation.data.response.CertificationRes
 import team.msg.domain.student.exception.StudentNotFoundException
 import team.msg.domain.student.model.Student
 import team.msg.domain.student.repository.StudentRepository
-import team.msg.domain.teacher.exception.TeacherNotFoundException
-import team.msg.domain.teacher.repository.TeacherRepository
-import team.msg.domain.user.enums.Authority
 import team.msg.domain.user.model.User
 import java.util.*
 
@@ -21,8 +18,7 @@ import java.util.*
 class CertificationServiceImpl(
     private val certificationRepository: CertificationRepository,
     private val studentRepository: StudentRepository,
-    private val userUtil: UserUtil,
-    private val teacherRepository: TeacherRepository,
+    private val userUtil: UserUtil
 ) : CertificationService {
 
     /**
@@ -44,12 +40,14 @@ class CertificationServiceImpl(
         certificationRepository.save(certification)
     }
 
+    /**
+     * 자격증 리스트를 조회하는 비지니스 로직입니다.
+     */
     @Transactional(readOnly = true)
     override fun queryAllCertifications(): AllCertificationsResponse {
         val user = userUtil.queryCurrentUser()
 
-        val student = studentRepository.findByUser(user)
-            ?: throw StudentNotFoundException("존재하지 않는 학생입니다. info : [ userId = ${user.id} ]")
+        val student = studentRepository findByUer user
 
         val certifications = certificationRepository.findAllByStudentId(student.id)
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
@@ -6,7 +6,7 @@ import team.msg.common.util.UserUtil
 import team.msg.domain.certifiacation.model.Certification
 import team.msg.domain.certifiacation.repository.CertificationRepository
 import team.msg.domain.certification.presentation.data.request.CreateCertificationRequest
-import team.msg.domain.certification.presentation.data.response.AllCertificationsResponse
+import team.msg.domain.certification.presentation.data.response.CertificationsResponse
 import team.msg.domain.certification.presentation.data.response.CertificationResponse
 import team.msg.domain.student.exception.StudentNotFoundException
 import team.msg.domain.student.model.Student
@@ -44,14 +44,14 @@ class CertificationServiceImpl(
      * 자격증 리스트를 조회하는 비지니스 로직입니다.
      */
     @Transactional(readOnly = true)
-    override fun queryAllCertifications(): AllCertificationsResponse {
+    override fun queryAllCertifications(): CertificationsResponse {
         val user = userUtil.queryCurrentUser()
 
         val student = studentRepository findByUer user
 
         val certifications = certificationRepository.findAllByStudentId(student.id)
 
-        val response = AllCertificationsResponse(
+        val response = CertificationsResponse(
             CertificationResponse.listOf(certifications)
         )
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import team.msg.domain.club.presentation.data.response.AllClubResponse
+import team.msg.domain.club.presentation.data.response.ClubsResponse
 import team.msg.domain.club.presentation.data.response.ClubDetailsResponse
 import team.msg.domain.club.service.ClubService
 import team.msg.domain.school.enums.HighSchool
@@ -19,7 +19,7 @@ class ClubController(
     private val clubService: ClubService
 ) {
     @GetMapping
-    fun queryAllClubs(@RequestParam("highSchool") highSchool: HighSchool): ResponseEntity<AllClubResponse> {
+    fun queryAllClubs(@RequestParam("highSchool") highSchool: HighSchool): ResponseEntity<ClubsResponse> {
         val response = clubService.queryAllClubsService(highSchool)
         return ResponseEntity.status(HttpStatus.OK).body(response)
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
@@ -22,7 +22,7 @@ data class ClubResponse(
     }
 }
 
-data class AllClubResponse(
+data class ClubsResponse(
     val club: List<ClubResponse>
 )
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
@@ -1,12 +1,12 @@
 package team.msg.domain.club.service
 
-import team.msg.domain.club.presentation.data.response.AllClubResponse
+import team.msg.domain.club.presentation.data.response.ClubsResponse
 import team.msg.domain.club.presentation.data.response.ClubDetailsResponse
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.student.presentation.data.response.AllStudentsResponse
 
 interface ClubService {
-    fun queryAllClubsService(highSchool: HighSchool): AllClubResponse
+    fun queryAllClubsService(highSchool: HighSchool): ClubsResponse
     fun queryClubDetailsService(id: Long): ClubDetailsResponse
     fun queryAllStudentsByClubId(id: Long): AllStudentsResponse
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
@@ -25,13 +25,13 @@ class ClubServiceImpl(
      * @param 동아리를 조회하기 위한 학교 이름
      */
     @Transactional(readOnly = true)
-    override fun queryAllClubsService(highSchool: HighSchool): AllClubResponse {
+    override fun queryAllClubsService(highSchool: HighSchool): ClubsResponse {
         val school = schoolRepository.findByHighSchool(highSchool)
             ?: throw SchoolNotFoundException("존재하지 않는 학교 입니다. info : [ highSchool = $highSchool ]")
 
         val clubs = clubRepository.findAllBySchool(school)
 
-        val response = AllClubResponse(
+        val response = ClubsResponse(
             ClubResponse.listOf(clubs)
         )
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/faq/presentation/FaqController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/faq/presentation/FaqController.kt
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import team.msg.domain.faq.mapper.FaqRequestMapper
-import team.msg.domain.faq.presentation.data.response.AllFaqResponse
+import team.msg.domain.faq.presentation.data.response.FaqsResponse
 import team.msg.domain.faq.presentation.data.response.FaqDetailsResponse
 import team.msg.domain.faq.presentation.web.CreateFaqWebRequest
 import team.msg.domain.faq.service.FaqService
@@ -24,7 +24,7 @@ class FaqController(
     }
 
     @GetMapping
-    fun queryAllFaqs(): ResponseEntity<AllFaqResponse> {
+    fun queryAllFaqs(): ResponseEntity<FaqsResponse> {
         val response = faqService.queryAllFaqs()
         return ResponseEntity.ok(response)
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/faq/presentation/data/response/FaqResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/faq/presentation/data/response/FaqResponse.kt
@@ -22,7 +22,7 @@ data class FaqResponse(
     }
 }
 
-data class AllFaqResponse(
+data class FaqsResponse(
     val faq: List<FaqResponse>
 )
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/faq/service/FAQServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/faq/service/FAQServiceImpl.kt
@@ -9,7 +9,7 @@ import team.msg.domain.admin.repository.AdminRepository
 import team.msg.domain.faq.exception.FaqNotFoundException
 import team.msg.domain.faq.model.Faq
 import team.msg.domain.faq.presentation.data.request.CreateFaqRequest
-import team.msg.domain.faq.presentation.data.response.AllFaqResponse
+import team.msg.domain.faq.presentation.data.response.FaqsResponse
 import team.msg.domain.faq.presentation.data.response.FaqDetailsResponse
 import team.msg.domain.faq.presentation.data.response.FaqResponse
 import team.msg.domain.faq.repository.FaqRepository
@@ -45,10 +45,10 @@ class FaqServiceImpl(
     * FAQ 전제 조회를 처리하는 비지니스 로직입니다.
     */
     @Transactional(rollbackFor = [Exception::class], readOnly = true)
-    override fun queryAllFaqs(): AllFaqResponse {
+    override fun queryAllFaqs(): FaqsResponse {
         val faqs = faqRepository.findAll()
 
-        val response = AllFaqResponse(
+        val response = FaqsResponse(
             FaqResponse.listOf(faqs)
         )
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/faq/service/FaqService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/faq/service/FaqService.kt
@@ -1,11 +1,11 @@
 package team.msg.domain.faq.service
 
 import team.msg.domain.faq.presentation.data.request.CreateFaqRequest
-import team.msg.domain.faq.presentation.data.response.AllFaqResponse
+import team.msg.domain.faq.presentation.data.response.FaqsResponse
 import team.msg.domain.faq.presentation.data.response.FaqDetailsResponse
 
 interface FaqService {
     fun createFaq(createFaqRequest: CreateFaqRequest)
-    fun queryAllFaqs(): AllFaqResponse
+    fun queryAllFaqs(): FaqsResponse
     fun queryFaqDetails(id: Long): FaqDetailsResponse
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import team.msg.domain.lecture.mapper.LectureRequestMapper
-import team.msg.domain.lecture.presentation.data.response.AllLecturesResponse
+import team.msg.domain.lecture.presentation.data.response.LecturesResponse
 import team.msg.domain.lecture.presentation.data.response.LectureDetailsResponse
 import team.msg.domain.lecture.presentation.web.CreateLectureWebRequest
 import team.msg.domain.lecture.presentation.web.QueryAllLecturesWebRequest
@@ -34,7 +34,7 @@ class LectureController(
     }
 
     @GetMapping
-    fun queryAllLectures(pageable: Pageable, WebRequest: QueryAllLecturesWebRequest): ResponseEntity<AllLecturesResponse>{
+    fun queryAllLectures(pageable: Pageable, WebRequest: QueryAllLecturesWebRequest): ResponseEntity<LecturesResponse>{
         val request = lectureRequestMapper.queryLectureWebRequestToDto(WebRequest)
         val response = lectureService.queryAllLectures(pageable, request)
         return ResponseEntity.status(HttpStatus.OK).body(response)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
@@ -51,7 +51,7 @@ data class LectureResponse(
     }
 }
 
-data class AllLecturesResponse(
+data class LecturesResponse(
     val lectures: Page<LectureResponse>
 )
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureService.kt
@@ -3,13 +3,13 @@ package team.msg.domain.lecture.service
 import org.springframework.data.domain.Pageable
 import team.msg.domain.lecture.presentation.data.request.CreateLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLectureRequest
-import team.msg.domain.lecture.presentation.data.response.AllLecturesResponse
+import team.msg.domain.lecture.presentation.data.response.LecturesResponse
 import team.msg.domain.lecture.presentation.data.response.LectureDetailsResponse
 import java.util.UUID
 
 interface LectureService {
     fun createLecture(request: CreateLectureRequest)
-    fun queryAllLectures(pageable: Pageable, queryAllLectureRequest: QueryAllLectureRequest): AllLecturesResponse
+    fun queryAllLectures(pageable: Pageable, queryAllLectureRequest: QueryAllLectureRequest): LecturesResponse
     fun queryLectureDetails(id: UUID): LectureDetailsResponse
     fun signUpLecture(id: UUID)
     fun approveLecture(id: UUID)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -19,7 +19,7 @@ import team.msg.domain.lecture.model.Lecture
 import team.msg.domain.lecture.model.RegisteredLecture
 import team.msg.domain.lecture.presentation.data.request.CreateLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLectureRequest
-import team.msg.domain.lecture.presentation.data.response.AllLecturesResponse
+import team.msg.domain.lecture.presentation.data.response.LecturesResponse
 import team.msg.domain.lecture.presentation.data.response.LectureDetailsResponse
 import team.msg.domain.lecture.presentation.data.response.LectureResponse
 import team.msg.domain.lecture.repository.LectureRepository
@@ -75,7 +75,7 @@ class LectureServiceImpl(
      * @return 조회한 강의의 정보를 담은 list dto
      */
     @Transactional(rollbackFor = [Exception::class], readOnly = true)
-    override fun queryAllLectures(pageable: Pageable, queryAllLectureRequest: QueryAllLectureRequest): AllLecturesResponse {
+    override fun queryAllLectures(pageable: Pageable, queryAllLectureRequest: QueryAllLectureRequest): LecturesResponse {
         val user = userUtil.queryCurrentUser()
 
         val approveStatus = queryAllLectureRequest.approveStatus
@@ -86,7 +86,7 @@ class LectureServiceImpl(
             else -> lectureRepository.findAllByApproveStatusAndLectureType(pageable, ApproveStatus.APPROVED, lectureType)
         }
 
-        val response = AllLecturesResponse(
+        val response = LecturesResponse(
             lectures.map {
                 val headCount = registeredLectureRepository.countByLecture(it)
                 LectureResponse.of(it,headCount)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/StudentActivityController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/StudentActivityController.kt
@@ -13,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import team.msg.domain.student.mapper.StudentActivityMapper
-import team.msg.domain.student.presentation.data.response.AllStudentActivitiesResponse
 import team.msg.domain.student.presentation.data.response.StudentActivitiesResponse
 import team.msg.domain.student.presentation.data.response.StudentActivityDetailsResponse
 import team.msg.domain.student.presentation.data.web.CreateStudentActivityWebRequest
@@ -60,7 +59,7 @@ class StudentActivityController(
     }
 
     @GetMapping
-    fun queryAllStudentActivities(pageable: Pageable): ResponseEntity<AllStudentActivitiesResponse> {
+    fun queryAllStudentActivities(pageable: Pageable): ResponseEntity<StudentActivitiesResponse> {
         val response = studentActivityService.queryAllStudentActivities(pageable)
         return ResponseEntity.status(HttpStatus.OK).body(response)
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentActivityResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentActivityResponse.kt
@@ -38,10 +38,6 @@ data class StudentActivityResponse(
     }
 }
 
-data class AllStudentActivitiesResponse(
-    val activities: Page<StudentActivityResponse>
-)
-
 data class StudentActivitiesResponse(
     val activities: Page<StudentActivityResponse>
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityService.kt
@@ -3,7 +3,6 @@ package team.msg.domain.student.service
 import org.springframework.data.domain.Pageable
 import team.msg.domain.student.presentation.data.request.CreateStudentActivityRequest
 import team.msg.domain.student.presentation.data.request.UpdateStudentActivityRequest
-import team.msg.domain.student.presentation.data.response.AllStudentActivitiesResponse
 import team.msg.domain.student.presentation.data.response.StudentActivitiesResponse
 import team.msg.domain.student.presentation.data.response.StudentActivityDetailsResponse
 import java.util.*
@@ -14,7 +13,7 @@ interface StudentActivityService {
     fun deleteStudentActivity(id: UUID)
     fun rejectStudentActivity(id: UUID)
     fun approveStudentActivity(id: UUID)
-    fun queryAllStudentActivities(pageable: Pageable): AllStudentActivitiesResponse
+    fun queryAllStudentActivities(pageable: Pageable): StudentActivitiesResponse
     fun queryStudentActivitiesByStudent(studentId: UUID, pageable: Pageable): StudentActivitiesResponse
     fun queryMyStudentActivities(pageable: Pageable): StudentActivitiesResponse
     fun queryStudentActivityDetail(id: UUID): StudentActivityDetailsResponse

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -20,7 +20,6 @@ import team.msg.domain.student.model.Student
 import team.msg.domain.student.model.StudentActivity
 import team.msg.domain.student.presentation.data.request.CreateStudentActivityRequest
 import team.msg.domain.student.presentation.data.request.UpdateStudentActivityRequest
-import team.msg.domain.student.presentation.data.response.AllStudentActivitiesResponse
 import team.msg.domain.student.presentation.data.response.StudentActivitiesResponse
 import team.msg.domain.student.presentation.data.response.StudentActivityDetailsResponse
 import team.msg.domain.student.presentation.data.response.StudentActivityResponse
@@ -168,12 +167,12 @@ class StudentActivityServiceImpl(
      * @param 학생활동을 페이징 처리하기 위한 pageable
      */
     @Transactional(readOnly = true)
-    override fun queryAllStudentActivities(pageable: Pageable): AllStudentActivitiesResponse {
+    override fun queryAllStudentActivities(pageable: Pageable): StudentActivitiesResponse {
         val user = userUtil.queryCurrentUser()
 
         val studentActivities = studentActivityRepository.findAll(pageable)
 
-        val response = AllStudentActivitiesResponse(
+        val response = StudentActivitiesResponse(
             StudentActivityResponse.pageOf(studentActivities, user)
         )
         

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -89,7 +89,8 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.GET, "/faq/{id}").permitAll()
 
             // certification
-            .mvcMatchers(HttpMethod.POST, "/certification/{student_id}").hasRole(STUDENT)
+            .mvcMatchers(HttpMethod.POST, "/certification").hasRole(STUDENT)
+            .mvcMatchers(HttpMethod.GET, "/certification").hasRole(STUDENT)
 
             // user
             .mvcMatchers(HttpMethod.GET, "/user").authenticated()

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/certifiacation/repository/CertificationRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/certifiacation/repository/CertificationRepository.kt
@@ -5,4 +5,5 @@ import team.msg.domain.certifiacation.model.Certification
 import java.util.UUID
 
 interface CertificationRepository : CrudRepository<Certification, UUID> {
+    fun findAllByStudentId(studentId: UUID): List<Certification>
 }


### PR DESCRIPTION
## 💡 개요
자격증 리스트 조회 학생 API 개발
## 📃 작업내용
학생을 조회할 때 infix 함수를 적용해 가독성을 높였습니다.
자격증 리스트를 조회할 때 studentId 가 권한에 따라 필요할 때도 있고 없을 때도 있어 api 를 학생용과 취동샘용, 2개로 나누었습니다.
