### PR TITLE
# 142 자격증 수정 API 개발

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/exception/CertificationNotFoundException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/exception/CertificationNotFoundException.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.certification.exception
+
+import team.msg.domain.certification.exception.constant.CertificationErrorCode
+import team.msg.global.error.exception.BitgouelException
+
+class CertificationNotFoundException(
+    message: String
+) : BitgouelException(message, CertificationErrorCode.FORBIDDEN_CERTIFICATION.status)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/mapper/CertificationRequestMapper.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/mapper/CertificationRequestMapper.kt
@@ -1,8 +1,11 @@
 package team.msg.domain.certification.mapper
 
 import team.msg.domain.certification.presentation.data.request.CreateCertificationRequest
+import team.msg.domain.certification.presentation.data.request.UpdateCertificationRequest
 import team.msg.domain.certification.presentation.data.web.CreateCertificationWebRequest
+import team.msg.domain.certification.presentation.data.web.UpdateCertificationWebRequest
 
 interface CertificationRequestMapper {
     fun createCertificationWebRequestToDto(webRequest: CreateCertificationWebRequest): CreateCertificationRequest
+    fun updateCertificationWebRequestToDto(webRequest: UpdateCertificationWebRequest): UpdateCertificationRequest
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/mapper/CertificationRequestMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/mapper/CertificationRequestMapperImpl.kt
@@ -2,7 +2,9 @@ package team.msg.domain.certification.mapper
 
 import org.springframework.stereotype.Component
 import team.msg.domain.certification.presentation.data.request.CreateCertificationRequest
+import team.msg.domain.certification.presentation.data.request.UpdateCertificationRequest
 import team.msg.domain.certification.presentation.data.web.CreateCertificationWebRequest
+import team.msg.domain.certification.presentation.data.web.UpdateCertificationWebRequest
 
 @Component
 class CertificationRequestMapperImpl : CertificationRequestMapper {
@@ -10,6 +12,14 @@ class CertificationRequestMapperImpl : CertificationRequestMapper {
      * 자격증 등록 Web Request 를 애플리케이션 영역에서 사용될 Dto 로 매핑합니다.
      */
     override fun createCertificationWebRequestToDto(webRequest: CreateCertificationWebRequest) = CreateCertificationRequest(
+        name = webRequest.name,
+        acquisitionDate = webRequest.acquisitionDate
+    )
+
+    /**
+     * 자격증 수정 Web Request 를 애플리케이션 영역에서 사용될 Dto 로 매핑합니다.
+     */
+    override fun updateCertificationWebRequestToDto(webRequest: UpdateCertificationWebRequest) = UpdateCertificationRequest(
         name = webRequest.name,
         acquisitionDate = webRequest.acquisitionDate
     )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/CertificationController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/CertificationController.kt
@@ -1,19 +1,15 @@
 package team.msg.domain.certification.presentation
 
-import javax.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import team.msg.domain.certification.mapper.CertificationRequestMapper
 import team.msg.domain.certification.presentation.data.response.CertificationsResponse
 import team.msg.domain.certification.presentation.data.web.CreateCertificationWebRequest
+import team.msg.domain.certification.presentation.data.web.UpdateCertificationWebRequest
 import team.msg.domain.certification.service.CertificationService
-import java.util.UUID
+import java.util.*
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/certification")
@@ -38,5 +34,12 @@ class CertificationController(
     fun queryCertifications(@PathVariable("student_id") studentId: UUID): ResponseEntity<CertificationsResponse> {
         val response = certificationService.queryCertifications(studentId)
         return ResponseEntity.status(HttpStatus.OK).body(response)
+    }
+
+    @PatchMapping("/{id}")
+    fun updateCertification(@PathVariable id: UUID, @RequestBody @Valid webRequest: UpdateCertificationWebRequest): ResponseEntity<Void> {
+        val request = certificationRequestMapper.updateCertificationWebRequestToDto(webRequest)
+        certificationService.updateCertification(id, request)
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/data/request/UpdateCertificationRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/data/request/UpdateCertificationRequest.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.certification.presentation.data.request
+
+import java.time.LocalDate
+
+data class UpdateCertificationRequest(
+    val name: String,
+    val acquisitionDate: LocalDate
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/data/web/UpdateCertificationWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/data/web/UpdateCertificationWebRequest.kt
@@ -1,0 +1,13 @@
+package team.msg.domain.certification.presentation.data.web
+
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.NotNull
+import java.time.LocalDate
+
+data class UpdateCertificationWebRequest(
+    @field:NotBlank
+    val name: String,
+
+    @field:NotNull
+    val acquisitionDate: LocalDate
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationService.kt
@@ -1,6 +1,7 @@
 package team.msg.domain.certification.service
 
 import team.msg.domain.certification.presentation.data.request.CreateCertificationRequest
+import team.msg.domain.certification.presentation.data.request.UpdateCertificationRequest
 import team.msg.domain.certification.presentation.data.response.CertificationsResponse
 import java.util.UUID
 
@@ -8,4 +9,5 @@ interface CertificationService {
     fun createCertification(createCertificationRequest: CreateCertificationRequest)
     fun queryCertifications(): CertificationsResponse
     fun queryCertifications(studentId: UUID): CertificationsResponse
+    fun updateCertification(id: UUID, updateCertificationRequest: UpdateCertificationRequest)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
@@ -36,7 +36,7 @@ class CertificationServiceImpl(
     @Transactional(rollbackFor = [Exception::class])
     override fun createCertification(request: CreateCertificationRequest) {
         val user = userUtil.queryCurrentUser()
-        val student = studentRepository findByUer user
+        val student = studentRepository findByUser user
 
         val certification = Certification(
             id = UUID.randomUUID(),
@@ -56,7 +56,7 @@ class CertificationServiceImpl(
     override fun queryCertifications(): CertificationsResponse {
         val user = userUtil.queryCurrentUser()
 
-        val student = studentRepository findByUer user
+        val student = studentRepository findByUser user
 
         val certifications = certificationRepository findAllByStudentId student.id
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
@@ -118,7 +118,7 @@ class CertificationServiceImpl(
 
     private infix fun StudentRepository.findByUer(user: User): Student =
         this.findByUser(user)
-            ?: throw StudentNotFoundException("존재하지 않는 유저입니다. info : [ userId = ${user.id} ]")
+            ?: throw StudentNotFoundException("존재하지 않는 학생입니다. info : [ userId = ${user.id} ]")
 
     private infix fun StudentRepository.findStudentById(studentId: UUID): Student =
         this.findStudentById(studentId)
@@ -133,5 +133,5 @@ class CertificationServiceImpl(
 
     private infix fun TeacherRepository.findByUser(user: User): Teacher =
         this.findByUser(user)
-            ?: throw TeacherNotFoundException("존재하지 않는 유저입니다. info : [ userId = ${user.id} ]")
+            ?: throw TeacherNotFoundException("존재하지 않는 선생님입니다. info : [ userId = ${user.id} ]")
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
@@ -92,13 +92,16 @@ class CertificationServiceImpl(
         return response
     }
 
+    /**
+     * 자격증을 수정하는 비지니스 로직입니다.
+     * @param 자격증 id, 수정할 자격증의 내용
+     */
     @Transactional(rollbackFor = [Exception::class])
     override fun updateCertification(id: UUID, updateCertificationRequest: UpdateCertificationRequest) {
         val user = userUtil.queryCurrentUser()
         val student = studentRepository findByUer user
 
-        val certification = certificationRepository.findByIdOrNull(id)
-            ?: throw CertificationNotFoundException("존재하지 않는 자격증입니다. info : [ certificationId = $id ]")
+        val certification = certificationRepository findById id
 
         if (student.id != certification.studentId)
             throw ForbiddenCertificationException("자격증을 수정할 권한이 없습니다. info : [ studentId = ${student.id} ]")
@@ -123,6 +126,10 @@ class CertificationServiceImpl(
 
     private infix fun CertificationRepository.findAllByStudentId(studentId: UUID): List<Certification> =
         this.findAllByStudentId(studentId)
+
+    private infix fun CertificationRepository.findById(id: UUID): Certification =
+        this.findByIdOrNull(id)
+            ?: throw CertificationNotFoundException("존재하지 않는 자격증입니다. info : [ certificationId = $id ]")
 
     private infix fun TeacherRepository.findByUser(user: User): Teacher =
         this.findByUser(user)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
@@ -99,7 +99,7 @@ class CertificationServiceImpl(
     @Transactional(rollbackFor = [Exception::class])
     override fun updateCertification(id: UUID, updateCertificationRequest: UpdateCertificationRequest) {
         val user = userUtil.queryCurrentUser()
-        val student = studentRepository findByUer user
+        val student = studentRepository findByUser user
 
         val certification = certificationRepository findById id
 

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -92,6 +92,7 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.POST, "/certification").hasRole(STUDENT)
             .mvcMatchers(HttpMethod.GET, "/certification").hasRole(STUDENT)
             .mvcMatchers(HttpMethod.GET, "/certification/{student_id}").hasRole(TEACHER)
+            .mvcMatchers(HttpMethod.PATCH, "/certification/{id}").hasRole(STUDENT)
 
             // user
             .mvcMatchers(HttpMethod.GET, "/user").authenticated()

--- a/bitgouel-api/src/main/resources/application.yml
+++ b/bitgouel-api/src/main/resources/application.yml
@@ -14,6 +14,7 @@ spring:
       ddl-auto: ${DDL_AUTO:update}
     properties:
       hibernate:
+        format_sql: true
         default_batch_fetch_size: 1000
 
   datasource:


### PR DESCRIPTION
## 💡 개요
자격증 수정 API 개발
## 📃 작업내용
webRequest 를 비지니스 로직에서 사용하는 dto 로 매핑합니다.
204 No Content 를 반환합니다.
자격증을 생성한 사람이 본인인 지 검증합니다.