### PR TITLE
137 유저 전체 조회 및 검색 api

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/mapper/AdminMapper.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/mapper/AdminMapper.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.admin.mapper
+
+import team.msg.domain.admin.presentation.data.request.QueryUsersRequest
+import team.msg.domain.admin.presentation.data.web.QueryUsersWebRequest
+
+interface AdminMapper {
+    fun queryUsersWebRequestToDto(webRequest: QueryUsersWebRequest): QueryUsersRequest
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/mapper/AdminMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/mapper/AdminMapperImpl.kt
@@ -1,0 +1,17 @@
+package team.msg.domain.admin.mapper
+
+import org.springframework.stereotype.Component
+import team.msg.domain.admin.presentation.data.request.QueryUsersRequest
+import team.msg.domain.admin.presentation.data.web.QueryUsersWebRequest
+
+@Component
+class AdminMapperImpl : AdminMapper {
+    /**
+     * User 조회 및 검색 Web Request를 애플리케이션 영역에서 사용될 Dto 로 매핑합니다.
+     */
+    override fun queryUsersWebRequestToDto(webRequest: QueryUsersWebRequest): QueryUsersRequest =
+        QueryUsersRequest(
+            keyword = webRequest.keyword,
+            authority = webRequest.authority
+        )
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
@@ -1,0 +1,23 @@
+package team.msg.domain.admin.presentation
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import team.msg.domain.admin.service.AdminService
+import team.msg.domain.user.presentation.data.response.UsersResponse
+
+@RestController
+@RequestMapping("/admin")
+class AdminController(
+    private val adminService: AdminService
+) {
+    @GetMapping
+    fun queryUser(@RequestParam keyword: String = ""): ResponseEntity<UsersResponse> {
+        val response = adminService.queryUsers(keyword)
+        return ResponseEntity.status(HttpStatus.OK).body(response)
+    }
+
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
@@ -1,5 +1,6 @@
 package team.msg.domain.admin.presentation
 
+import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -15,8 +16,8 @@ class AdminController(
     private val adminService: AdminService
 ) {
     @GetMapping
-    fun queryUser(@RequestParam keyword: String = ""): ResponseEntity<UsersResponse> {
-        val response = adminService.queryUsers(keyword)
+    fun queryUser(@RequestParam keyword: String = "", pageable: Pageable): ResponseEntity<UsersResponse> {
+        val response = adminService.queryUsers(keyword, pageable)
         return ResponseEntity.status(HttpStatus.OK).body(response)
     }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
@@ -1,24 +1,26 @@
 package team.msg.domain.admin.presentation
 
 import org.springframework.data.domain.Pageable
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import team.msg.domain.admin.mapper.AdminMapper
+import team.msg.domain.admin.presentation.data.web.QueryUsersWebRequest
 import team.msg.domain.admin.service.AdminService
 import team.msg.domain.user.presentation.data.response.UsersResponse
 
 @RestController
 @RequestMapping("/admin")
 class AdminController(
-    private val adminService: AdminService
+    private val adminService: AdminService,
+    private val adminMapper: AdminMapper
 ) {
     @GetMapping
-    fun queryUser(@RequestParam keyword: String = "", pageable: Pageable): ResponseEntity<UsersResponse> {
-        val response = adminService.queryUsers(keyword, pageable)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+    fun queryUser(webRequest: QueryUsersWebRequest,pageable: Pageable): ResponseEntity<UsersResponse> {
+        val request = adminMapper.queryUsersWebRequestToDto(webRequest)
+        val response = adminService.queryUsers(request, pageable)
+        return ResponseEntity.ok(response)
     }
 
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
@@ -17,7 +17,7 @@ class AdminController(
     private val adminMapper: AdminMapper
 ) {
     @GetMapping
-    fun queryUser(webRequest: QueryUsersWebRequest,pageable: Pageable): ResponseEntity<UsersResponse> {
+    fun queryUser(webRequest: QueryUsersWebRequest, pageable: Pageable): ResponseEntity<UsersResponse> {
         val request = adminMapper.queryUsersWebRequestToDto(webRequest)
         val response = adminService.queryUsers(request, pageable)
         return ResponseEntity.ok(response)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/data/request/QueryUsersRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/data/request/QueryUsersRequest.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.admin.presentation.data.request
+
+import team.msg.domain.user.enums.Authority
+
+data class QueryUsersRequest(
+    val keyword: String,
+    val authority: Authority
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/data/web/QueryUsersWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/data/web/QueryUsersWebRequest.kt
@@ -3,7 +3,7 @@ package team.msg.domain.admin.presentation.data.web
 import org.springframework.web.bind.annotation.RequestParam
 import team.msg.domain.user.enums.Authority
 
-class QueryUsersWebRequest(
+data class QueryUsersWebRequest(
     @RequestParam(required = false)
     val keyword: String = "",
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/data/web/QueryUsersWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/data/web/QueryUsersWebRequest.kt
@@ -1,0 +1,12 @@
+package team.msg.domain.admin.presentation.data.web
+
+import org.springframework.web.bind.annotation.RequestParam
+import team.msg.domain.user.enums.Authority
+
+class QueryUsersWebRequest(
+    @RequestParam(required = false)
+    val keyword: String = "",
+
+    @RequestParam(required = false)
+    val authority: Authority = Authority.ROLE_USER
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminService.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.admin.service
+
+import org.springframework.data.domain.Pageable
+import team.msg.domain.user.presentation.data.response.UsersResponse
+
+interface AdminService {
+    fun queryUsers(keyword: String, pageable: Pageable): UsersResponse
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminService.kt
@@ -1,8 +1,9 @@
 package team.msg.domain.admin.service
 
 import org.springframework.data.domain.Pageable
+import team.msg.domain.admin.presentation.data.request.QueryUsersRequest
 import team.msg.domain.user.presentation.data.response.UsersResponse
 
 interface AdminService {
-    fun queryUsers(keyword: String, pageable: Pageable): UsersResponse
+    fun queryUsers(request: QueryUsersRequest,pageable: Pageable): UsersResponse
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -13,6 +13,7 @@ class AdminServiceImpl(
     /**
      * 유저를 전체 조회 및 이름으로 조회하는 비즈니스 로직입니다
      * @param 유저를 검색하기 위한 keyword 및 페이징을 처리하기 위한 pageable
+     * @return 페이징된 학생 정보를 담은 Dto
      */
     override fun queryUsers(keyword: String, pageable: Pageable): UsersResponse {
         val users =

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -16,7 +16,7 @@ class AdminServiceImpl(
      * @param 유저를 검색하기 위한 keyword 및 페이징을 처리하기 위한 pageable
      * @return 페이징된 학생 정보를 담은 Dto
      */
-    override fun queryUsers(request: QueryUsersRequest,pageable: Pageable): UsersResponse {
+    override fun queryUsers(request: QueryUsersRequest, pageable: Pageable): UsersResponse {
         val users = userRepository.query(request.keyword, request.authority, pageable)
 
         return UserResponse.pageOf(users)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -10,6 +10,10 @@ import team.msg.domain.user.repository.UserRepository
 class AdminServiceImpl(
     private val userRepository: UserRepository
 ) : AdminService {
+    /**
+     * 유저를 전체 조회 및 이름으로 조회하는 비즈니스 로직입니다
+     * @param 유저를 검색하기 위한 keyword 및 페이징을 처리하기 위한 pageable
+     */
     override fun queryUsers(keyword: String, pageable: Pageable): UsersResponse {
         val users =
             if(keyword == "")

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -1,0 +1,22 @@
+package team.msg.domain.admin.service
+
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import team.msg.domain.user.presentation.data.response.UserResponse
+import team.msg.domain.user.presentation.data.response.UsersResponse
+import team.msg.domain.user.repository.UserRepository
+
+@Service
+class AdminServiceImpl(
+    private val userRepository: UserRepository
+) : AdminService {
+    override fun queryUsers(keyword: String, pageable: Pageable): UsersResponse {
+        val users =
+            if(keyword == "")
+                userRepository.findAll(pageable)
+            else
+                userRepository.findByNameContaining(keyword, pageable)
+
+        return UserResponse.pageOf(users)
+    }
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -2,6 +2,7 @@ package team.msg.domain.admin.service
 
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import team.msg.domain.admin.presentation.data.request.QueryUsersRequest
 import team.msg.domain.user.presentation.data.response.UserResponse
 import team.msg.domain.user.presentation.data.response.UsersResponse
 import team.msg.domain.user.repository.UserRepository
@@ -15,12 +16,8 @@ class AdminServiceImpl(
      * @param 유저를 검색하기 위한 keyword 및 페이징을 처리하기 위한 pageable
      * @return 페이징된 학생 정보를 담은 Dto
      */
-    override fun queryUsers(keyword: String, pageable: Pageable): UsersResponse {
-        val users =
-            if(keyword == "")
-                userRepository.findAll(pageable)
-            else
-                userRepository.findByNameContaining(keyword, pageable)
+    override fun queryUsers(request: QueryUsersRequest,pageable: Pageable): UsersResponse {
+        val users = userRepository.query(request.keyword, request.authority, pageable)
 
         return UserResponse.pageOf(users)
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/user/presentation/UserController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/user/presentation/UserController.kt
@@ -16,6 +16,6 @@ class UserController (
     @GetMapping
     fun queryUserPage(): ResponseEntity<UserPageResponse> {
         val response = userService.queryUserPageService()
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/user/presentation/data/response/UserResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/user/presentation/data/response/UserResponse.kt
@@ -20,14 +20,16 @@ data class UserResponse (
             organization = organization
         )
 
+        fun of(user: User) = AdminUserResponse(
+            id = user.id,
+            name = user.name,
+            authority = user.authority,
+            approveStatus = user.approveStatus
+        )
+
         fun pageOf(users: Page<User>) = UsersResponse(
             users.map {
-                AdminUserResponse(
-                    id = it.id,
-                    name = it.name,
-                    authority = it.authority,
-                    approveStatus = it.approveStatus
-                )
+                of(it)
             }
         )
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/user/presentation/data/response/UserResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/user/presentation/data/response/UserResponse.kt
@@ -1,5 +1,7 @@
 package team.msg.domain.user.presentation.data.response
 
+import org.springframework.data.domain.Page
+import team.msg.common.enums.ApproveStatus
 import team.msg.domain.user.enums.Authority
 import team.msg.domain.user.model.User
 import java.util.*
@@ -17,6 +19,17 @@ data class UserResponse (
             authority = user.authority,
             organization = organization
         )
+
+        fun pageOf(users: Page<User>) = UsersResponse(
+            users.map {
+                AdminUserResponse(
+                    id = it.id,
+                    name = it.name,
+                    authority = it.authority,
+                    approveStatus = it.approveStatus
+                )
+            }
+        )
     }
 }
 
@@ -26,4 +39,16 @@ data class UserPageResponse (
     val phoneNumber: String,
     val authority: Authority,
     val organization: String
+)
+
+data class AdminUserResponse(
+    val id: UUID,
+    val name: String,
+    val authority: Authority,
+    val approveStatus: ApproveStatus
+)
+
+data class UsersResponse(
+    val users: Page<AdminUserResponse>
+
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -98,7 +98,7 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.GET, "/user").authenticated()
 
             //admin
-            .mvcMatchers(HttpMethod.GET, "admin").hasRole(ADMIN)
+            .mvcMatchers(HttpMethod.GET, "/admin").hasRole(ADMIN)
 
             .anyRequest().authenticated()
             .and()

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -94,6 +94,9 @@ class SecurityConfig(
             // user
             .mvcMatchers(HttpMethod.GET, "/user").authenticated()
 
+            //admin
+            .mvcMatchers(HttpMethod.GET, "admin").hasRole(ADMIN)
+
             .anyRequest().authenticated()
             .and()
 

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/CustomUserRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/CustomUserRepository.kt
@@ -1,0 +1,10 @@
+package team.msg.domain.user.repository
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import team.msg.domain.user.enums.Authority
+import team.msg.domain.user.model.User
+
+interface CustomUserRepository {
+    fun query(keyword: String, authority: Authority, pageable: Pageable): Page<User>
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/CustomUserRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/CustomUserRepositoryImpl.kt
@@ -22,7 +22,7 @@ class CustomUserRepositoryImpl(
             )
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
-            .orderBy(user.authority.asc())
+            .orderBy(user.name.asc())
             .fetch()
 
         return PageImpl(users)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/CustomUserRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/CustomUserRepositoryImpl.kt
@@ -14,6 +14,10 @@ class CustomUserRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ) : CustomUserRepository {
     override fun query(keyword: String, authority: Authority, pageable: Pageable): Page<User> {
+
+        /**
+         * User를 authority, name 순으로 정렬 및 페이징하여 조회하는 쿼리입니다
+         */
         val users = queryFactory
             .selectFrom(user)
             .where(
@@ -25,6 +29,9 @@ class CustomUserRepositoryImpl(
             .orderBy(user.authority.asc(), user.name.asc())
             .fetch()
 
+        /**
+         * 검색 조건에 맞게 조회된 행의 개수를 조회하는 쿼리입니다
+         */
         val countQuery = queryFactory
             .select(user.count())
             .where(

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/CustomUserRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/CustomUserRepositoryImpl.kt
@@ -1,0 +1,36 @@
+package team.msg.domain.user.repository
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
+import team.msg.domain.user.enums.Authority
+import team.msg.domain.user.model.QUser.user
+import team.msg.domain.user.model.User
+import java.util.Objects.isNull
+
+class CustomUserRepositoryImpl(
+    private val queryFactory: JPAQueryFactory
+) : CustomUserRepository {
+    override fun query(keyword: String, authority: Authority, pageable: Pageable): Page<User> {
+        val users = queryFactory
+            .selectFrom(user)
+            .where(
+                nameLike(keyword),
+                authorityEq(authority)
+            )
+            .offset(pageable.offset)
+            .limit(pageable.pageSize.toLong())
+            .orderBy(user.authority.asc())
+            .fetch()
+
+        return PageImpl(users)
+    }
+
+    private fun nameLike(keyword: String): BooleanExpression? =
+        if(keyword == "") null else user.name.like(keyword)
+
+    private fun authorityEq(authority: Authority): BooleanExpression? =
+        if(authority == Authority.ROLE_USER) null else user.authority.eq(authority)
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/CustomUserRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/CustomUserRepositoryImpl.kt
@@ -25,7 +25,15 @@ class CustomUserRepositoryImpl(
             .orderBy(user.authority.asc(), user.name.asc())
             .fetch()
 
-        return PageImpl(users)
+        val countQuery = queryFactory
+            .select(user.count())
+            .where(
+                nameLike(keyword),
+                authorityEq(authority)
+            )
+            .from(user)
+
+        return PageableExecutionUtils.getPage(users, pageable) { countQuery.fetchOne()!! }
     }
 
     private fun nameLike(keyword: String): BooleanExpression? =

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/CustomUserRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/CustomUserRepositoryImpl.kt
@@ -5,10 +5,10 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
+import org.springframework.data.support.PageableExecutionUtils
 import team.msg.domain.user.enums.Authority
 import team.msg.domain.user.model.QUser.user
 import team.msg.domain.user.model.User
-import java.util.Objects.isNull
 
 class CustomUserRepositoryImpl(
     private val queryFactory: JPAQueryFactory
@@ -22,7 +22,7 @@ class CustomUserRepositoryImpl(
             )
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
-            .orderBy(user.name.asc())
+            .orderBy(user.authority.asc(), user.name.asc())
             .fetch()
 
         return PageImpl(users)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/UserRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/UserRepository.kt
@@ -6,11 +6,8 @@ import org.springframework.data.repository.CrudRepository
 import team.msg.domain.user.model.User
 import java.util.UUID
 
-interface UserRepository : CrudRepository<User, UUID> {
+interface UserRepository : CrudRepository<User, UUID>, CustomUserRepository {
     fun existsByEmail(email: String): Boolean
     fun existsByPhoneNumber(phoneNumber: String): Boolean
     fun findByEmail(email: String): User?
-
-    fun findByNameContaining(keyword: String, pageable: Pageable): Page<User>
-    fun findAll(pageable: Pageable): Page<User>
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/UserRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/UserRepository.kt
@@ -1,5 +1,7 @@
 package team.msg.domain.user.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.user.model.User
 import java.util.UUID
@@ -8,4 +10,7 @@ interface UserRepository : CrudRepository<User, UUID> {
     fun existsByEmail(email: String): Boolean
     fun existsByPhoneNumber(phoneNumber: String): Boolean
     fun findByEmail(email: String): User?
+
+    fun findByNameContaining(keyword: String, pageable: Pageable): Page<User>
+    fun findAll(pageable: Pageable): Page<User>
 }


### PR DESCRIPTION
## 💡 개요
유저를 전체 검색하거나 이름을 통해 검색하는 기능을 개발하였습니다
## 📃 작업내용
* userList를 페이징 처리하기 위하여 userRepository에 findAll 재정의
* user를 keyword에 맞게 검색하기 위한 findByNameContaining 쿼리 메소드 재정의
* API 명세서에 정의된 Response 필드들을 반환하기 위한 UsersResponse 클래스
* 페이징 처리된 user를 Response로 변환하기 위한 listOf 함수 오버로딩

