### PR TITLE
deploy sh 배포 플로우 수정

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,24 +1,28 @@
-#!/bin/bash
-BUILD_JAR=$(ls /home/ec2-user/Bitgouel-Server/bitgouel-api/build/libs/*.jar)
-JAR_NAME=$(basename $BUILD_JAR)
-echo "> build 파일명: $JAR_NAME" >> /home/ec2-user/deploy.log
+REPOSITORY=/home/ec2-user/
+PROJECT_NAME=Bitgouel-Server
+JAR_PATH=$REPOSITORY/$PROJECT_NAME/bitgouel-api/build/libs/*.jar
 
-echo "> build 파일 복사" >> /home/ec2-user/deploy.log
-DEPLOY_PATH=/home/ec2-user/
-cp $BUILD_JAR $DEPLOY_PATH
+cd $REPOSITORY/$PROJECT_NAME/
 
-echo "> 현재 실행중인 애플리케이션 pid 확인" >> /home/ec2-user/deploy.log
-CURRENT_PID=$(pgrep -f $JAR_NAME)
+echo "> Git Pull"
+git pull origin master
 
-if [ -z $CURRENT_PID ]
-then
-  echo "> 현재 구동중인 애플리케이션이 없으므로 종료하지 않습니다." >> /home/ec2-user/deploy.log
+echo "> Project Build"
+./gradlew clean bitgouel-api:build
+
+echo "> Build 파일 복사"
+
+
+CURRENT_PID=$(lsof -i tcp:8080 | awk `NR!=1 {print$2}`)
+if [ -z "$CURRENT_PID" ]; then
+    echo "> 현재 구동중인 애플리케이션이 없으므로 종료하지 않습니다."
 else
-  echo "> kill -15 $CURRENT_PID"
-  kill -15 $CURRENT_PID
-  sleep 5
+    echo "> kill -9 $CURRENT_PID"
+    kill -9 $CURRENT_PID
+    sleep 5
 fi
 
-DEPLOY_JAR=$DEPLOY_PATH$JAR_NAME
-echo "> DEPLOY_JAR 배포"    >> /home/ec2-user/deploy.log
-nohup java -jar $DEPLOY_JAR --logging.file.path=/home/ec2-user/ --logging.level.org.hibernate.SQL=DEBUG >> /home/ec2-user/deploy.log 2>/home/ec2-user/deploy_err.log &
+echo "> 애플리케이션 배포"
+JAR_NAME=$(ls -tr $JAR_PATH | tail -n 1)
+echo "> JAR NAME: $JAR_NAME"
+nohup java -jar $JAR_NAME --logging.file.path=/home/ec2-user/ 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,9 +10,6 @@ git pull origin master
 echo "> Project Build"
 ./gradlew clean bitgouel-api:build
 
-echo "> Build 파일 복사"
-
-
 CURRENT_PID=$(lsof -i tcp:8080 | awk `NR!=1 {print$2}`)
 if [ -z "$CURRENT_PID" ]; then
     echo "> 현재 구동중인 애플리케이션이 없으므로 종료하지 않습니다."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -22,4 +22,4 @@ fi
 echo "> 애플리케이션 배포"
 JAR_NAME=$(ls -tr $JAR_PATH | tail -n 1)
 echo "> JAR NAME: $JAR_NAME"
-nohup java -jar $JAR_NAME --logging.file.path=/home/ec2-user/ 
+nohup java -jar $JAR_NAME  --logging.file.path=/home/ec2-user/ --logging.level.org.hibernate.SQL=DEBUG >> /home/ec2-user/deploy.log 2>/home/ec2-user/deploy_err.log &


### PR DESCRIPTION
## 💡 개요
deploy.sh 스크립트에서 배포 과정이 잘못되어 cd가 적용되지 않았습니다.
새로운 플로우를 정의하여 해결하겠습니다.

다음과 같은 과정으로 배포를 진행합니다.

Git Pull -> Multimodule gradlew build -> :8080 프로세스 존재 확인/취소 -> JAR 파일 무중단 배포(로깅 기록)

## 📃 작업내용
`deploy.sh` 수정
