### PR TITLE
# 162 로그인 시 response 에 Authority 추가

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/data/response/TokenResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/data/response/TokenResponse.kt
@@ -1,10 +1,12 @@
 package team.msg.domain.auth.presentation.data.response
 
+import team.msg.domain.user.enums.Authority
 import java.time.LocalDateTime
 
 data class TokenResponse(
     val accessToken: String,
     val refreshToken: String,
     val accessExpiredAt: LocalDateTime,
-    val refreshExpiredAt: LocalDateTime
+    val refreshExpiredAt: LocalDateTime,
+    val authority: Authority
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -12,7 +12,6 @@ import team.msg.domain.auth.presentation.data.request.*
 import team.msg.domain.auth.presentation.data.response.TokenResponse
 import team.msg.domain.auth.repository.RefreshTokenRepository
 import team.msg.domain.bbozzak.model.Bbozzak
-import team.msg.domain.auth.presentation.data.request.BbozzakSignUpRequest
 import team.msg.domain.bbozzak.repository.BbozzakRepository
 import team.msg.domain.club.exception.ClubNotFoundException
 import team.msg.domain.club.model.Club

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/jwt/JwtTokenGenerator.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/jwt/JwtTokenGenerator.kt
@@ -23,7 +23,7 @@ class JwtTokenGenerator(
         val accessExpiredAt = getAccessTokenExpiredAt()
         val refreshExpiredAt = getRefreshTokenExpiredAt()
         refreshTokenRepository.save(RefreshToken(refreshToken, userId, authority, jwtProperties.refreshExpiration))
-        return TokenResponse(accessToken, refreshToken, accessExpiredAt, refreshExpiredAt)
+        return TokenResponse(accessToken, refreshToken, accessExpiredAt, refreshExpiredAt, authority)
     }
 
     private fun generateAccessToken(userId: UUID, secret: Key, authority: Authority): String =


### PR DESCRIPTION
## 💡 개요
로그인 시 response 에 Authority 추가
## 📃 작업내용
<img width="460" alt="image" src="https://github.com/GSM-MSG/Bitgouel-Server/assets/103554978/2c66c277-dcd5-4a78-9167-7625c5700227">

학생활동 승인에 권한을 식별하는 게 필요해 로그인 시에 Authority 를 추가로 반환해줍니다.
