### PR TITLE
180 feat/query student activity bug

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -187,7 +187,7 @@ class StudentActivityServiceImpl(
     override fun queryStudentActivitiesByStudent(studentId: UUID, pageable: Pageable): StudentActivitiesResponse {
         val user = userUtil.queryCurrentUser()
 
-        val student = studentRepository findByUser user
+        val student = studentRepository findById studentId
 
         val teacher = teacherRepository findByUser user
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -260,6 +260,9 @@ class StudentActivityServiceImpl(
     private infix fun StudentRepository.findByUser(user: User): Student =
         this.findByUser(user) ?: throw StudentNotFoundException("학생을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
 
+    private infix fun StudentRepository.findById(id: UUID): Student =
+        this.findByIdOrNull(id) ?: throw throw StudentNotFoundException("학생을 찾을 수 없습니다. info : [ userId = $id ]")
+
     private infix fun StudentActivityRepository.findById(id: UUID): StudentActivity =
         this.findByIdOrNull(id) ?: throw StudentActivityNotFoundException("학생 활동을 찾을 수 없습니다. info : [ studentActivityId = $id ]")
 


### PR DESCRIPTION
## 💡 개요
학생 활동 학생 단위로 조회 시 아무런 문제가 없는데도 학생을 찾지 못하였을 때 발생하는 404 status의 경위를 확인하여 보니 파라미터로 받아온 학생 id를 사용하고 있던 것이 아닌 AccessToken에 담긴 user를 통해 조회하고 있었습니다.
## 📃 작업내용
* 파라미터로 받아온 학생 id로 조회하도록 변경
* StudentRepository.findById infix 함수 정의
## 🔀 변경사항

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
