### PR TITLE
178 학생 활동 승인 시 학생활동 히스토리 업데이트

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/handler/StudentActivityEventHandler.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/handler/StudentActivityEventHandler.kt
@@ -37,29 +37,14 @@ class StudentActivityEventHandler(
     }
 
     /**
-     * StudentActivity의 approve 이벤트가 발행되면 이전의 히스토리들을 삭제하고 최신 히스토리를 저장하는 핸들러 입니다.
+     * StudentActivity의 approve 이벤트가 발행되면 이전의 히스토리들을 삭제하는 핸들러 입니다.
      * @param studentActivity approve 이벤트
      */
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     fun approveStudentActivityHandler(event: ApproveStudentActivityEvent) {
         val studentActivity = event.studentActivity
 
-        studentActivityHistoryRepository.deleteAllByStudentId(studentActivity.id)
+        studentActivityHistoryRepository.deleteAllByStudentActivityId(studentActivity.id)
 
-        val latestStudentActivityHistory = studentActivity.run {
-            StudentActivityHistory(
-                id = UUID.randomUUID(),
-                title = title,
-                content = content,
-                credit = credit,
-                approveStatus = approveStatus,
-                activityDate = activityDate,
-                student = student,
-                teacher = teacher,
-                studentActivityId = studentActivity.id
-            )
-        }
-
-        studentActivityHistoryRepository.save(latestStudentActivityHistory)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/handler/StudentActivityEventHandler.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/handler/StudentActivityEventHandler.kt
@@ -44,7 +44,7 @@ class StudentActivityEventHandler(
     fun approveStudentActivityHandler(event: ApproveStudentActivityEvent) {
         val studentActivity = event.studentActivity
 
-        studentActivityHistoryRepository.deleteAllByStudent(studentActivity.id)
+        studentActivityHistoryRepository.deleteAllByStudentId(studentActivity.id)
 
         val latestStudentActivityHistory = studentActivity.run {
             StudentActivityHistory(

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/handler/StudentActivityEventHandler.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/handler/StudentActivityEventHandler.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component
 import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 import team.msg.common.enums.ApproveStatus
+import team.msg.domain.student.event.ApproveStudentActivityEvent
 import team.msg.domain.student.event.UpdateStudentActivityEvent
 import team.msg.domain.student.model.StudentActivityHistory
 import team.msg.domain.student.repository.StudentActivityHistoryRepository
@@ -33,5 +34,32 @@ class StudentActivityEventHandler(
             studentActivityId = studentActivity.id
         )
         studentActivityHistoryRepository.save(studentActivityHistory)
+    }
+
+    /**
+     * StudentActivity의 approve 이벤트가 발행되면 이전의 히스토리들을 삭제하고 최신 히스토리를 저장하는 핸들러 입니다.
+     * @param studentActivity approve 이벤트
+     */
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    fun approveStudentActivityHandler(event: ApproveStudentActivityEvent) {
+        val studentActivity = event.studentActivity
+
+        studentActivityHistoryRepository.deleteAllByStudent(studentActivity.id)
+
+        val latestStudentActivityHistory = studentActivity.run {
+            StudentActivityHistory(
+                id = UUID.randomUUID(),
+                title = title,
+                content = content,
+                credit = credit,
+                approveStatus = approveStatus,
+                activityDate = activityDate,
+                student = student,
+                teacher = teacher,
+                studentActivityId = studentActivity.id
+            )
+        }
+
+        studentActivityHistoryRepository.save(latestStudentActivityHistory)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/handler/StudentActivityEventHandler.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/handler/StudentActivityEventHandler.kt
@@ -42,9 +42,6 @@ class StudentActivityEventHandler(
      */
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     fun approveStudentActivityHandler(event: ApproveStudentActivityEvent) {
-        val studentActivity = event.studentActivity
-
-        studentActivityHistoryRepository.deleteAllByStudentActivityId(studentActivity.id)
-
+        studentActivityHistoryRepository.deleteAllByStudentActivityId(event.studentActivityId)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -12,6 +12,7 @@ import team.msg.domain.club.model.Club
 import team.msg.domain.company.model.CompanyInstructor
 import team.msg.domain.government.model.Government
 import team.msg.domain.professor.model.Professor
+import team.msg.domain.student.event.ApproveStudentActivityEvent
 import team.msg.domain.student.event.UpdateStudentActivityEvent
 import team.msg.domain.student.exception.ForbiddenStudentActivityException
 import team.msg.domain.student.exception.StudentActivityNotFoundException
@@ -159,6 +160,7 @@ class StudentActivityServiceImpl(
             teacher = studentActivity.teacher
         )
 
+        applicationEventPublisher.publishEvent(ApproveStudentActivityEvent(studentActivity))
         studentActivityRepository.save(updatedStudentActivity)
     }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -160,7 +160,7 @@ class StudentActivityServiceImpl(
             teacher = studentActivity.teacher
         )
 
-        applicationEventPublisher.publishEvent(ApproveStudentActivityEvent(studentActivity))
+        applicationEventPublisher.publishEvent(ApproveStudentActivityEvent(id))
         studentActivityRepository.save(updatedStudentActivity)
     }
 

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/event/ApproveStudentActivityEvent.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/event/ApproveStudentActivityEvent.kt
@@ -1,0 +1,11 @@
+package team.msg.domain.student.event
+
+import team.msg.domain.student.model.StudentActivity
+
+/**
+ * StudentActivity를 승인하는 이벤트를 나타냅니다.
+ * StudentActivity를 구독자에게 알리기 위해서 사용됩니다.
+ */
+data class ApproveStudentActivityEvent(
+    val studentActivity: StudentActivity
+)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/event/ApproveStudentActivityEvent.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/event/ApproveStudentActivityEvent.kt
@@ -1,11 +1,11 @@
 package team.msg.domain.student.event
 
-import team.msg.domain.student.model.StudentActivity
+import java.util.*
 
 /**
  * StudentActivity를 승인하는 이벤트를 나타냅니다.
  * StudentActivity를 구독자에게 알리기 위해서 사용됩니다.
  */
 data class ApproveStudentActivityEvent(
-    val studentActivity: StudentActivity
+    val studentActivityId: UUID
 )

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/custom/CustomStudentActivityHistoryRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/custom/CustomStudentActivityHistoryRepository.kt
@@ -4,4 +4,5 @@ import java.util.*
 
 interface CustomStudentActivityHistoryRepository {
     fun deleteAllByStudentId(studentId: UUID)
+    fun deleteAllByStudentActivityId(studentActivityId: UUID)
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/custom/impl/CustomStudentActivityHistoryRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/custom/impl/CustomStudentActivityHistoryRepositoryImpl.kt
@@ -13,4 +13,10 @@ class CustomStudentActivityHistoryRepositoryImpl(
             .where(studentActivityHistory.student.id.eq(studentId))
             .execute()
     }
+
+    override fun deleteAllByStudentActivityId(studentActivityId: UUID) {
+        queryFactory.delete(studentActivityHistory)
+            .where(studentActivityHistory.studentActivityId.eq(studentActivityId))
+            .execute()
+    }
 }


### PR DESCRIPTION
## 💡 개요
학생 활동 승인시 이전의 히스토리 삭제 후 가장 최신의 히스토리만을 저장하도록 eventHandler를 통해 처리했습니다
## 📃 작업내용
* ApproveStudentActivityEvent
* ApproveStudentActivityEventHandler
## 🔀 변경사항
학생 활동 승인 시 ApproveStudentActivityEvent를 발행하는 코드가 추가되었습니다
