### PR TITLE
강의 상세정보 조회 Response 값 항목 추가

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
@@ -37,7 +37,7 @@ data class LectureResponse(
             lecturer = lecture.instructor
         )
 
-        fun detailOf(lecture: Lecture, headCount: Int): LectureDetailsResponse = LectureDetailsResponse(
+        fun detailOf(lecture: Lecture, headCount: Int, isRegistered: Boolean): LectureDetailsResponse = LectureDetailsResponse(
             name = lecture.name,
             content = lecture.content,
             createAt = lecture.createdAt,
@@ -49,6 +49,7 @@ data class LectureResponse(
             approveStatus = lecture.approveStatus,
             headCount = headCount,
             maxRegisteredUser = lecture.maxRegisteredUser,
+            isRegistered = isRegistered,
             lecturer = lecture.instructor,
             credit = lecture.credit
         )
@@ -71,6 +72,7 @@ data class LectureDetailsResponse(
     val approveStatus: ApproveStatus,
     val headCount: Int,
     val maxRegisteredUser: Int,
+    val isRegistered: Boolean,
     val lecturer: String,
     val credit: Int
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -76,7 +76,7 @@ class LectureServiceImpl(
      * @param 조회할 강의의 승인 상태를 담은 request dto와 pageable dto
      * @return 조회한 강의의 정보를 담은 list dto
      */
-    @Transactional(rollbackFor = [Exception::class], readOnly = true)
+    @Transactional(readOnly = true)
     override fun queryAllLectures(pageable: Pageable, queryAllLectureRequest: QueryAllLectureRequest): LecturesResponse {
         val user = userUtil.queryCurrentUser()
 
@@ -103,7 +103,7 @@ class LectureServiceImpl(
      * @param 상세 조회할 강의의 id
      * @return 강의의 상세조회 정보를 담은 detail dto
      */
-    @Transactional(rollbackFor = [Exception::class], readOnly = true)
+    @Transactional(readOnly = true)
     override fun queryLectureDetails(id: UUID): LectureDetailsResponse {
         val user = userUtil.queryCurrentUser()
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -111,7 +111,12 @@ class LectureServiceImpl(
 
         val headCount = registeredLectureRepository.countByLecture(lecture)
 
-        val response = LectureResponse.detailOf(lecture, headCount)
+        val isRegistered = if(user.authority == Authority.ROLE_STUDENT) {
+            val student = studentRepository findByUser user
+            registeredLectureRepository.existsByStudentAndLecture(student, lecture)
+        } else false
+
+        val response = LectureResponse.detailOf(lecture, headCount, isRegistered)
 
         return response
     }


### PR DESCRIPTION
## 💡 개요
- 강의 상세정보 조회 Response 값에 isRegistered 항목을 추가했습니다.

## 📃 작업내용
- LectureResponse detailOf 매개변수 추가
- 학생이 아닌 다른 직업군은 false를 반환

## 🔀 변경사항
- infix 함수를 사용하도록 변경했습니다.
- 트랜잭션 rollback 옵션을 삭제했습니다.