### PR TITLE
196 link -> links 로 이름 변경 

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/mapper/PostRequestMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/mapper/PostRequestMapperImpl.kt
@@ -15,7 +15,7 @@ class PostRequestMapperImpl : PostRequestMapper {
         CreatePostRequest(
             title = title,
             content = content,
-            link = link.map { it.url },
+            links = links.map { it.url },
             feedType = feedType
         )
     }
@@ -27,7 +27,7 @@ class PostRequestMapperImpl : PostRequestMapper {
         UpdatePostRequest(
             title = title,
             content = content,
-            link = link.map { it.url }
+            links = links.map { it.url }
         )
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/data/request/CreatePostRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/data/request/CreatePostRequest.kt
@@ -5,6 +5,6 @@ import team.msg.domain.post.enums.FeedType
 data class CreatePostRequest(
     val title: String,
     val content: String,
-    val link: List<String>,
+    val links: List<String>,
     val feedType: FeedType
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/data/request/UpdatePostRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/data/request/UpdatePostRequest.kt
@@ -3,5 +3,5 @@ package team.msg.domain.post.presentation.data.request
 data class UpdatePostRequest(
     val title: String,
     val content: String,
-    val link: List<String>
+    val links: List<String>
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/data/response/PostResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/data/response/PostResponse.kt
@@ -33,7 +33,7 @@ data class PostResponse (
                 content = post.content,
                 feedType = post.feedType,
                 modifiedAt = post.modifiedAt,
-                links = post.link
+                links = post.links
             )
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/web/CreatePostWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/web/CreatePostWebRequest.kt
@@ -17,7 +17,7 @@ data class CreatePostWebRequest(
     val content: String,
 
     @field:Valid
-    val link: List<LinkWebRequest>,
+    val links: List<LinkWebRequest>,
 
     @field:NotNull
     val feedType: FeedType

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/web/UpdatePostWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/web/UpdatePostWebRequest.kt
@@ -15,7 +15,7 @@ data class UpdatePostWebRequest(
     val content: String,
 
     @field:Valid
-    val link: List<LinkWebRequest>
+    val links: List<LinkWebRequest>
 ){
     data class LinkWebRequest(
         @field:URL

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
@@ -44,7 +44,7 @@ class PostServiceImpl(
                 feedType = feedType,
                 title = title,
                 content = content,
-                link = links
+                links = links
             )
         }
 
@@ -70,7 +70,7 @@ class PostServiceImpl(
             feedType = post.feedType,
             title = request.title,
             content = request.content,
-            link = request.links,
+            links = request.links,
         )
 
         postRepository.save(updatePost)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
@@ -44,7 +44,7 @@ class PostServiceImpl(
                 feedType = feedType,
                 title = title,
                 content = content,
-                link = link
+                link = links
             )
         }
 
@@ -70,7 +70,7 @@ class PostServiceImpl(
             feedType = post.feedType,
             title = request.title,
             content = request.content,
-            link = request.link,
+            link = request.links,
         )
 
         postRepository.save(updatePost)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/post/model/Post.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/post/model/Post.kt
@@ -30,7 +30,7 @@ class Post (
         name = "Link",
         joinColumns = [JoinColumn(name = "post_id")]
     )
-    val link: List<String>,
+    val links: List<String>,
 
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)


### PR DESCRIPTION
## 💡 개요
api 명세서에 따라 link -> links 로 이름을 변경했습니다.

## 🔀 변경사항
- web request data의 link를 links로 변경
- post entity의 link 컬럼명을 links로 변경