### PR TITLE
게시글 삭제 권한 검증 로직 리팩토링

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
@@ -88,12 +88,14 @@ class PostServiceImpl(
 
         when(post.feedType){
             FeedType.EMPLOYMENT -> {
-                if(user.id != post.userId)
-                    if(user.authority != Authority.ROLE_ADMIN)
+                if (user.authority != Authority.ROLE_ADMIN) {
+                    if (user.id != post.userId) {
                         throw ForbiddenPostException("게시글은 작성자 또는 관리자만 삭제할 수 있습니다. info : [ userId = ${user.id}, authority = ${user.authority} ]")
+                    }
+                }
             }
             FeedType.NOTICE -> {
-                if(user.authority != Authority.ROLE_ADMIN)
+                if (user.authority != Authority.ROLE_ADMIN)
                     throw ForbiddenPostException("공지는 관리자만 삭제할 수 있습니다. info : [ userId = ${user.id}, authority = ${user.authority} ]")
             }
         }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
@@ -86,8 +86,17 @@ class PostServiceImpl(
 
         val post = postRepository findById id
 
-        if(user.id != post.userId && user.authority != Authority.ROLE_ADMIN)
-           throw ForbiddenPostException("게시글은 작성자 또는 관리자만 삭제할 수 있습니다. info : [ userId = ${user.id} ]")
+        when(post.feedType){
+            FeedType.EMPLOYMENT -> {
+                if(user.id != post.userId)
+                    if(user.authority != Authority.ROLE_ADMIN)
+                        throw ForbiddenPostException("게시글은 작성자 또는 관리자만 삭제할 수 있습니다. info : [ userId = ${user.id}, authority = ${user.authority} ]")
+            }
+            FeedType.NOTICE -> {
+                if(user.authority != Authority.ROLE_ADMIN)
+                    throw ForbiddenPostException("공지는 관리자만 삭제할 수 있습니다. info : [ userId = ${user.id}, authority = ${user.authority} ]")
+            }
+        }
 
         postRepository.delete(post)
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
@@ -61,8 +61,16 @@ class PostServiceImpl(
 
         val post = postRepository findById id
 
-        if(user.id != post.userId)
-            throw ForbiddenPostException("게시글은 본인만 수정할 수 있습니다. info : [ userId = ${user.id} ]")
+        when(post.feedType){
+            FeedType.EMPLOYMENT -> {
+                if (user.id != post.userId)
+                    throw ForbiddenPostException("게시글은 본인만 수정할 수 있습니다. info : [ userId = ${user.id} ]")
+            }
+            FeedType.NOTICE -> {
+                if (user.authority != Authority.ROLE_ADMIN)
+                    throw ForbiddenPostException("공지는 관리자만 수정할 수 있습니다. info : [ userId = ${user.id}, authority = ${user.authority} ]")
+            }
+        }
 
         val updatePost = Post(
             id = post.id,


### PR DESCRIPTION
## 💡 개요

게시글 삭제 api의 권한 검증 로직을 리팩토링했습니다.

## 📃 작업내용
게시글 타입에 따라 삭제에 대한 권한 검증을 따로 처리하도록 했습니다.
