### PR TITLE
185 user save 코드 삭제

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -286,7 +286,7 @@ class AuthServiceImpl(
         if (userRepository.existsByPhoneNumber(phoneNumber))
             throw AlreadyExistPhoneNumberException("이미 가입된 전화번호를 기입하였습니다. info : [ phoneNumber = $phoneNumber ]")
 
-        val user = User(
+        return User(
             id = UUID.randomUUID(),
             email = email,
             name = name,
@@ -295,8 +295,6 @@ class AuthServiceImpl(
             authority = authority,
             approveStatus = ApproveStatus.PENDING
         )
-
-        return userRepository.save(user)
     }
 
     /**


### PR DESCRIPTION
## 💡 개요
user save 코드 삭제
## 📃 작업내용
CasCade Merge type 으로 유저와 1:1 로 관계가 맺어진 학생(교수, 기업강사 ..)를 save할 때 user도 같이 save가 되기 때문에 user save 코드를 삭제 해주었습니다.
