### PR TITLE
Post의 user_id 컬럼에 columnDefinition 옵션을 추가했습니다.

### DIFF
--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/post/model/Post.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/post/model/Post.kt
@@ -16,7 +16,7 @@ class Post (
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
-    @Column(name = "user_id")
+    @Column(name = "user_id", columnDefinition = "BINARY(16)")
     val userId: UUID,
 
     @Column(columnDefinition = "VARCHAR(100)", nullable = false)


### PR DESCRIPTION
## 💡 개요
Post의 user_id 컬럼에 columnDefinition 옵션을 추가했습니다.

## 📃 작업내용
![image](https://github.com/GSM-MSG/Bitgouel-Server/assets/106813267/66215f70-da39-4b50-9fcf-e131c8228164)

user_id 컬럼을 binary 데이터 타입으로 지정해주었습니다.
