### PR TITLE
동아리에 소속된 학생의 상세정보 조회 api

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
@@ -39,8 +39,8 @@ class ClubController(
     }
 
     @GetMapping("/{id}/{student_id}")
-    fun queryStudentDetails(@PathVariable id: Long, @PathVariable("student_id") studentId: UUID): ResponseEntity<StudentDetailsResponse> {
-        val response = clubService.queryStudentDetails(id, studentId)
+    fun queryStudentDetails(@PathVariable("id") clubId: Long, @PathVariable("student_id") studentId: UUID): ResponseEntity<StudentDetailsResponse> {
+        val response = clubService.queryStudentDetails(clubId, studentId)
         return ResponseEntity.status(HttpStatus.OK).body(response)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
@@ -12,6 +12,8 @@ import team.msg.domain.club.presentation.data.response.ClubDetailsResponse
 import team.msg.domain.club.service.ClubService
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.student.presentation.data.response.AllStudentsResponse
+import team.msg.domain.student.presentation.data.response.StudentDetailsResponse
+import java.util.UUID
 
 @RestController
 @RequestMapping("/club")
@@ -33,6 +35,12 @@ class ClubController(
     @GetMapping("/{id}/member")
     fun queryUserByClubId(@PathVariable id: Long): ResponseEntity<AllStudentsResponse> {
         val response = clubService.queryAllStudentsByClubId(id)
+        return ResponseEntity.status(HttpStatus.OK).body(response)
+    }
+
+    @GetMapping("/{id}/{student_id}")
+    fun queryStudentDetails(@PathVariable id: Long, @PathVariable("student_id") studentId: UUID): ResponseEntity<StudentDetailsResponse> {
+        val response = clubService.queryStudentDetails(id, studentId)
         return ResponseEntity.status(HttpStatus.OK).body(response)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
@@ -11,5 +11,5 @@ interface ClubService {
     fun queryAllClubsService(highSchool: HighSchool): ClubsResponse
     fun queryClubDetailsService(id: Long): ClubDetailsResponse
     fun queryAllStudentsByClubId(id: Long): AllStudentsResponse
-    fun queryStudentDetails(id: Long, studentId: UUID): StudentDetailsResponse
+    fun queryStudentDetails(clubId: Long,studentId: UUID): StudentDetailsResponse
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
@@ -4,9 +4,12 @@ import team.msg.domain.club.presentation.data.response.ClubsResponse
 import team.msg.domain.club.presentation.data.response.ClubDetailsResponse
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.student.presentation.data.response.AllStudentsResponse
+import team.msg.domain.student.presentation.data.response.StudentDetailsResponse
+import java.util.UUID
 
 interface ClubService {
     fun queryAllClubsService(highSchool: HighSchool): ClubsResponse
     fun queryClubDetailsService(id: Long): ClubDetailsResponse
     fun queryAllStudentsByClubId(id: Long): AllStudentsResponse
+    fun queryStudentDetails(id: Long, studentId: UUID): StudentDetailsResponse
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
@@ -82,12 +82,12 @@ class ClubServiceImpl(
      * @param 동아리 id, 동아리에 속한 상세정보를 조회할 학생 id
      */
     @Transactional(readOnly = true)
-    override fun queryStudentDetails(id: Long, studentId: UUID): StudentDetailsResponse {
-        val club = clubRepository.findByIdOrNull(id)
-            ?: throw ClubNotFoundException("존재하지 않는 동아리입니다. info : [ clubId = $id ]")
+    override fun queryStudentDetails(clubId: Long, studentId: UUID): StudentDetailsResponse {
+        val club = clubRepository.findByIdOrNull(clubId)
+            ?: throw ClubNotFoundException("존재하지 않는 동아리입니다. info : [ clubId = $clubId ]")
 
         val student = studentRepository.findByIdAndClub(studentId, club)
-            ?: throw StudentNotFoundException("동아리에 존재하지 않는 학생입니다. info : [ clubId = $id, studentId = $studentId ]")
+            ?: throw StudentNotFoundException("동아리에 존재하지 않는 학생입니다. info : [ clubId = $clubId, studentId = $studentId ]")
 
         val credit = registeredLectureRepository.findAllByStudent(student)
             .sumOf { it.lecture.credit }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
@@ -6,7 +6,6 @@ import org.springframework.transaction.annotation.Transactional
 import team.msg.domain.club.exception.ClubNotFoundException
 import team.msg.domain.club.presentation.data.response.*
 import team.msg.domain.club.repository.ClubRepository
-import team.msg.domain.lecture.repository.RegisteredLectureRepository
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.school.exception.SchoolNotFoundException
 import team.msg.domain.school.repository.SchoolRepository
@@ -27,6 +26,7 @@ class ClubServiceImpl(
     /**
      * 모든 동아리를 조회하는 비즈니스 로직
      * @param 동아리를 조회하기 위한 학교 이름
+     * @return 학교에 있는 취업동아리 리스트
      */
     @Transactional(readOnly = true)
     override fun queryAllClubsService(highSchool: HighSchool): ClubsResponse {
@@ -45,6 +45,7 @@ class ClubServiceImpl(
     /**
      * 동아리를 상세 조회하는 비즈니스 로직
      * @param 동아리를 상세 조회하기 위한 id
+     * @return 동아리 상세 정보를 담은 dto
      */
     @Transactional(readOnly = true)
     override fun queryClubDetailsService(id: Long): ClubDetailsResponse {
@@ -61,6 +62,7 @@ class ClubServiceImpl(
     /**
      * 동아리를의 학생 리스트를 조회하는 비즈니스 로직
      * @param 동아리에 속한 학생 리스트를 조회하기 위한 id
+     * @return 동아리에 속한 학생 리스트를 담은 dto
      */
     @Transactional(readOnly = true)
     override fun queryAllStudentsByClubId(id: Long): AllStudentsResponse {
@@ -79,6 +81,7 @@ class ClubServiceImpl(
     /**
      * 동아리에 소속된 학생의 상세정보를 조회하는 비즈니스 로직
      * @param 동아리 id, 동아리에 속한 상세정보를 조회할 학생 id
+     * @return 동아리에 속한 학생의 상세정보를 담은 dto
      */
     @Transactional(readOnly = true)
     override fun queryStudentDetails(clubId: Long, studentId: UUID): StudentDetailsResponse {

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
@@ -21,8 +21,7 @@ import java.util.*
 class ClubServiceImpl(
     private val clubRepository: ClubRepository,
     private val schoolRepository: SchoolRepository,
-    private val studentRepository: StudentRepository,
-    private val registeredLectureRepository: RegisteredLectureRepository
+    private val studentRepository: StudentRepository
 ) : ClubService {
 
     /**
@@ -89,10 +88,7 @@ class ClubServiceImpl(
         val student = studentRepository.findByIdAndClub(studentId, club)
             ?: throw StudentNotFoundException("동아리에 존재하지 않는 학생입니다. info : [ clubId = $clubId, studentId = $studentId ]")
 
-        val credit = registeredLectureRepository.findAllByStudent(student)
-            .sumOf { it.lecture.credit }
-
-        val response = StudentResponse.detailOf(student, credit)
+        val response = StudentResponse.detailOf(student)
 
         return response
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -156,6 +156,19 @@ class LectureServiceImpl(
 
         registeredLectureRepository.save(registeredLecture)
 
+        val updateCreditStudent = Student(
+            id = student.id,
+            user = student.user,
+            club = student.club,
+            grade = student.grade,
+            classRoom = student.classRoom,
+            number = student.number,
+            cohort = student.cohort,
+            credit = student.credit + lecture.credit,
+            studentRole = student.studentRole
+        )
+
+        studentRepository.save(updateCreditStudent)
     }
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentResponse.kt
@@ -17,9 +17,23 @@ class StudentResponse(
                 authority = it.user!!.authority
             )
         }
+
+        fun detailOf(student: Student, credit: Int) = StudentDetailsResponse(
+            name = student.user!!.name,
+            phoneNumber = student.user!!.phoneNumber,
+            email = student.user!!.email,
+            credit = credit
+        )
     }
 }
 
 data class AllStudentsResponse(
     val students: List<StudentResponse>
+)
+
+data class StudentDetailsResponse(
+    val name: String,
+    val phoneNumber: String,
+    val email: String,
+    val credit: Int
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentResponse.kt
@@ -12,7 +12,7 @@ class StudentResponse(
     companion object {
         fun listOf(students: List<Student>) = students.map {
             StudentResponse(
-                id = it.user!!.id,
+                id = it.id,
                 name = it.user!!.name,
                 authority = it.user!!.authority
             )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentResponse.kt
@@ -18,11 +18,11 @@ class StudentResponse(
             )
         }
 
-        fun detailOf(student: Student, credit: Int) = StudentDetailsResponse(
+        fun detailOf(student: Student) = StudentDetailsResponse(
             name = student.user!!.name,
             phoneNumber = student.user!!.phoneNumber,
             email = student.user!!.email,
-            credit = credit
+            credit = student.credit
         )
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -63,6 +63,7 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.GET, "/club").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/club/{id}").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
             .mvcMatchers(HttpMethod.GET, "/club/{id}/member").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
+            .mvcMatchers(HttpMethod.GET, "/club/{id}/{student_id}").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
 
             // activity
             .mvcMatchers(HttpMethod.POST, "/activity").hasRole(STUDENT)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/StudentRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/StudentRepository.kt
@@ -13,6 +13,8 @@ interface StudentRepository : CrudRepository<Student, UUID> {
     fun findByUser(user: User): Student?
     @EntityGraph(attributePaths = ["user"], type = EntityGraph.EntityGraphType.FETCH)
     fun findStudentById(id: UUID): Student?
+    @EntityGraph(attributePaths = ["user"], type = EntityGraph.EntityGraphType.FETCH)
+    fun findByIdAndClub(id: UUID, club: Club): Student?
     fun countByClub(club: Club): Long
     fun findAllByClub(club: Club): List<Student>
 }


### PR DESCRIPTION
## 💡 개요
동아리에 소속된 학생의 상세정보를 조회하는 api를 작성했습니다.

## 📃 작업내용
club id와 student id를 받아 학생의 상세정보를 조회합니다.

## 🔀 변경사항

동아리에 소속된 학생 리스트를 반환하는 StudentResponse에서, student id가 아닌 user id를 반환하고 있어 번경해주었습니다.