### PR TITLE
214 feat/query inquiry admin user

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/mapper/InquiryMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/mapper/InquiryMapperImpl.kt
@@ -8,6 +8,9 @@ import team.msg.domain.inquiry.presentation.web.CreateInquiryWebRequest
 class InquiryMapperImpl : InquiryMapper {
 
     override fun createInquiryWebRequestToDto(webRequest: CreateInquiryWebRequest): CreateInquiryRequest =
-        CreateInquiryRequest(webRequest.question)
+        CreateInquiryRequest(
+            question = webRequest.question,
+            questionDetail = webRequest.questionDetail
+        )
 
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/InquiryController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/InquiryController.kt
@@ -3,11 +3,15 @@ package team.msg.domain.inquiry.presentation
 import javax.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import team.msg.domain.inquiry.enums.AnswerStatus
 import team.msg.domain.inquiry.mapper.InquiryMapper
+import team.msg.domain.inquiry.presentation.response.InquiryResponses
 import team.msg.domain.inquiry.presentation.web.CreateInquiryWebRequest
 import team.msg.domain.inquiry.service.InquiryService
 
@@ -23,5 +27,16 @@ class InquiryController(
         val request = inquiryMapper.createInquiryWebRequestToDto(webRequest)
         inquiryService.createInquiry(request)
         return ResponseEntity.status(HttpStatus.CREATED).build()
+    }
+
+    @GetMapping
+    fun queryMyInquiries(): ResponseEntity<InquiryResponses> {
+        val response = inquiryService.queryMyInquiries()
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/all")
+    fun queryAllInquires(@RequestParam answerStatus: AnswerStatus? = null, @RequestParam keyword: String = ""): ResponseEntity<InquiryResponses> {
+
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/InquiryController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/InquiryController.kt
@@ -36,7 +36,9 @@ class InquiryController(
     }
 
     @GetMapping("/all")
-    fun queryAllInquires(@RequestParam answerStatus: AnswerStatus? = null, @RequestParam keyword: String = ""): ResponseEntity<InquiryResponses> {
-
+    fun queryAllInquires(@RequestParam answerStatus: AnswerStatus? = null,
+                         @RequestParam keyword: String = ""): ResponseEntity<InquiryResponses> {
+        val response = inquiryService.queryAllInquiries(answerStatus,keyword)
+        return ResponseEntity.ok(response)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/request/CreateInquiryRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/request/CreateInquiryRequest.kt
@@ -1,5 +1,6 @@
 package team.msg.domain.inquiry.presentation.request
 
 data class CreateInquiryRequest(
-    val question: String
+    val question: String,
+    val questionDetail: String
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/response/InquiryResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/response/InquiryResponse.kt
@@ -1,0 +1,36 @@
+package team.msg.domain.inquiry.presentation.response
+
+import team.msg.domain.inquiry.enums.AnswerStatus
+import team.msg.domain.inquiry.model.Inquiry
+import java.time.LocalDateTime
+import java.util.*
+
+data class InquiryResponse(
+    val id: UUID,
+    val question: String,
+    val userId: UUID,
+    val username: String,
+    val createdAt: LocalDateTime,
+    val answerStatus: AnswerStatus
+) {
+    companion object {
+
+        fun of(inquiry: Inquiry): InquiryResponse =
+            InquiryResponse(
+                id = inquiry.id,
+                question = inquiry.question,
+                userId = inquiry.user.id,
+                username = inquiry.user.name,
+                createdAt = inquiry.createdAt,
+                answerStatus = inquiry.answerStatus
+            )
+
+        fun listOf(inquiries: List<Inquiry>): InquiryResponses = InquiryResponses(
+            inquiries.map { of(it) }
+        )
+    }
+}
+
+data class InquiryResponses(
+    val inquiries: List<InquiryResponse>
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/web/CreateInquiryWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/web/CreateInquiryWebRequest.kt
@@ -5,6 +5,10 @@ import javax.validation.constraints.Size
 
 data class CreateInquiryWebRequest(
     @field:NotBlank
+    @field:Size(max=100)
+    val question: String,
+
+    @field:NotBlank
     @field:Size(max=1000)
-    val question: String
+    val questionDetail: String
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryService.kt
@@ -7,5 +7,5 @@ import team.msg.domain.inquiry.presentation.response.InquiryResponses
 interface InquiryService {
     fun createInquiry(request: CreateInquiryRequest)
     fun queryMyInquiries(): InquiryResponses
-    fun queryAllInquiries(answerStatus: AnswerStatus, keyword: String): InquiryResponses
+    fun queryAllInquiries(answerStatus: AnswerStatus?, keyword: String): InquiryResponses
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryService.kt
@@ -1,7 +1,11 @@
 package team.msg.domain.inquiry.service
 
+import team.msg.domain.inquiry.enums.AnswerStatus
 import team.msg.domain.inquiry.presentation.request.CreateInquiryRequest
+import team.msg.domain.inquiry.presentation.response.InquiryResponses
 
 interface InquiryService {
     fun createInquiry(request: CreateInquiryRequest)
+    fun queryMyInquiries(): InquiryResponses
+    fun queryAllInquiries(answerStatus: AnswerStatus, keyword: String): InquiryResponses
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
@@ -2,6 +2,7 @@ package team.msg.domain.inquiry.service
 
 import org.springframework.stereotype.Service
 import team.msg.common.util.UserUtil
+import team.msg.domain.inquiry.enums.AnswerStatus
 import team.msg.domain.inquiry.model.Inquiry
 import team.msg.domain.inquiry.presentation.request.CreateInquiryRequest
 import team.msg.domain.inquiry.repository.InquiryRepository
@@ -30,7 +31,8 @@ class InquiryServiceImpl(
         val inquiry = Inquiry(
             id = UUID.randomUUID(),
             userId = userId,
-            question = request.question
+            question = request.question,
+            answerStatus = AnswerStatus.UNANSWERED
         )
 
         inquiryRepository.save(inquiry)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
@@ -15,8 +15,7 @@ import java.util.*
 @Service
 class InquiryServiceImpl(
     private val userUtil: UserUtil,
-    private val inquiryRepository: InquiryRepository,
-    private val userRepository: UserRepository
+    private val inquiryRepository: InquiryRepository
 ) : InquiryService {
 
     /**
@@ -31,12 +30,17 @@ class InquiryServiceImpl(
             id = UUID.randomUUID(),
             user = currentUser,
             question = request.question,
+            questionDetail = request.questionDetail,
             answerStatus = AnswerStatus.UNANSWERED
         )
 
         inquiryRepository.save(inquiry)
     }
 
+    /**
+     * 유저가 자신이 등록한 문의 사항을 조회하는 비즈니스 로직입니다.
+     * @return 자신이 등록한 문의사항 response
+     */
     override fun queryMyInquiries(): InquiryResponses {
         val currentUser = userUtil.queryCurrentUser()
 
@@ -45,7 +49,16 @@ class InquiryServiceImpl(
         return InquiryResponse.listOf(inquiries)
     }
 
+    /**
+     * 전체 문의 사항을 조회하는 비즈니스 로직입니다.
+     * 답변 상태, 키워드를 통해 필터링 합니다.
+     * @param 답변 여부 상태, 키워드
+     * @return 자신이 등록한 문의사항 response
+     */
     override fun queryAllInquiries(answerStatus: AnswerStatus?, keyword: String): InquiryResponses {
-        TODO("Not yet implemented")
+
+        val inquiries = inquiryRepository.search(answerStatus,keyword)
+
+        return InquiryResponse.listOf(inquiries)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
@@ -45,7 +45,7 @@ class InquiryServiceImpl(
         return InquiryResponse.listOf(inquiries)
     }
 
-    override fun queryAllInquiries(answerStatus: AnswerStatus, keyword: String): InquiryResponses {
+    override fun queryAllInquiries(answerStatus: AnswerStatus?, keyword: String): InquiryResponses {
         TODO("Not yet implemented")
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
@@ -1,6 +1,7 @@
 package team.msg.domain.inquiry.service
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import team.msg.common.util.UserUtil
 import team.msg.domain.inquiry.enums.AnswerStatus
 import team.msg.domain.inquiry.model.Inquiry
@@ -23,6 +24,7 @@ class InquiryServiceImpl(
      * @param question이 담겨있는 request
      * @return Unit
      */
+    @Transactional
     override fun createInquiry(request: CreateInquiryRequest) {
         val currentUser = userUtil.queryCurrentUser()
 
@@ -41,6 +43,7 @@ class InquiryServiceImpl(
      * 유저가 자신이 등록한 문의 사항을 조회하는 비즈니스 로직입니다.
      * @return 자신이 등록한 문의사항 response
      */
+    @Transactional(readOnly = true)
     override fun queryMyInquiries(): InquiryResponses {
         val currentUser = userUtil.queryCurrentUser()
 
@@ -55,6 +58,7 @@ class InquiryServiceImpl(
      * @param 답변 여부 상태, 키워드
      * @return 자신이 등록한 문의사항 response
      */
+    @Transactional(readOnly = true)
     override fun queryAllInquiries(answerStatus: AnswerStatus?, keyword: String): InquiryResponses {
 
         val inquiries = inquiryRepository.search(answerStatus,keyword)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
@@ -23,14 +23,11 @@ class InquiryServiceImpl(
      * @return Unit
      */
     override fun createInquiry(request: CreateInquiryRequest) {
-        val userId = userUtil.queryCurrentUserId()
-
-        if(!userRepository.existsById(userId))
-            throw UserNotFoundException("존재하지 않는 유저입니다. : [ id = $userId ]")
+        val user = userUtil.queryCurrentUser()
 
         val inquiry = Inquiry(
             id = UUID.randomUUID(),
-            userId = userId,
+            user = user,
             question = request.question,
             answerStatus = AnswerStatus.UNANSWERED
         )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
@@ -5,6 +5,8 @@ import team.msg.common.util.UserUtil
 import team.msg.domain.inquiry.enums.AnswerStatus
 import team.msg.domain.inquiry.model.Inquiry
 import team.msg.domain.inquiry.presentation.request.CreateInquiryRequest
+import team.msg.domain.inquiry.presentation.response.InquiryResponse
+import team.msg.domain.inquiry.presentation.response.InquiryResponses
 import team.msg.domain.inquiry.repository.InquiryRepository
 import team.msg.domain.user.exception.UserNotFoundException
 import team.msg.domain.user.repository.UserRepository
@@ -23,15 +25,27 @@ class InquiryServiceImpl(
      * @return Unit
      */
     override fun createInquiry(request: CreateInquiryRequest) {
-        val user = userUtil.queryCurrentUser()
+        val currentUser = userUtil.queryCurrentUser()
 
         val inquiry = Inquiry(
             id = UUID.randomUUID(),
-            user = user,
+            user = currentUser,
             question = request.question,
             answerStatus = AnswerStatus.UNANSWERED
         )
 
         inquiryRepository.save(inquiry)
+    }
+
+    override fun queryMyInquiries(): InquiryResponses {
+        val currentUser = userUtil.queryCurrentUser()
+
+        val inquiries = inquiryRepository.findByUser(currentUser)
+
+        return InquiryResponse.listOf(inquiries)
+    }
+
+    override fun queryAllInquiries(answerStatus: AnswerStatus, keyword: String): InquiryResponses {
+        TODO("Not yet implemented")
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -18,7 +18,7 @@ import team.msg.domain.inquiry.repository.InquiryRepository
 
 @EnableWebSecurity
 class SecurityConfig(
-    private val jwtTokenParser: JwtTokenParser,private val inquiryAnswerRepository: InquiryAnswerRepository,private val inquiryRepository: InquiryRepository
+    private val jwtTokenParser: JwtTokenParser
 ) {
     companion object {
         const val USER = "USER"

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -112,7 +112,7 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.DELETE, "/admin/{user_id}").hasRole(ADMIN)
 
             // inquiry
-            .mvcMatchers(HttpMethod.POST, "/inquiry").authenticated() // TODO hasRole("USER")랑 별반 다를거 없지 않을까, 오히려 이게 낫지 않을까..? 얘기해보기
+            .mvcMatchers(HttpMethod.POST, "/inquiry").authenticated()
             .mvcMatchers(HttpMethod.GET, "/inquiry").hasAnyRole(STUDENT, TEACHER, BBOZZAK, PROFESSOR, GOVERNMENT, COMPANY_INSTRUCTOR, )
             .mvcMatchers(HttpMethod.GET, "/all").hasRole(ADMIN)
 

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -112,7 +112,9 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.DELETE, "/admin/{user_id}").hasRole(ADMIN)
 
             // inquiry
-            .mvcMatchers(HttpMethod.POST, "/inquiry").authenticated()
+            .mvcMatchers(HttpMethod.POST, "/inquiry").authenticated() // TODO hasRole("USER")랑 별반 다를거 없지 않을까, 오히려 이게 낫지 않을까..? 얘기해보기
+            .mvcMatchers(HttpMethod.GET, "/inquiry").hasAnyRole(STUDENT, TEACHER, BBOZZAK, PROFESSOR, GOVERNMENT, COMPANY_INSTRUCTOR, )
+            .mvcMatchers(HttpMethod.GET, "/all").hasRole(ADMIN)
 
             .anyRequest().authenticated()
             .and()

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/enums/AnswerStatus.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/enums/AnswerStatus.kt
@@ -1,0 +1,5 @@
+package team.msg.domain.inquiry.enums
+
+enum class AnswerStatus {
+    ANSWERED, UNANSWERED
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/model/Inquiry.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/model/Inquiry.kt
@@ -2,7 +2,10 @@ package team.msg.domain.inquiry.model
 
 import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import team.msg.common.entity.BaseUUIDEntity
+import team.msg.domain.inquiry.enums.AnswerStatus
 import java.util.*
 
 @Entity
@@ -15,4 +18,8 @@ class Inquiry(
 
     @Column(columnDefinition = "VARCHAR(1000)", nullable = false)
     val question: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "answer_status", nullable = false)
+    val answerStatus: AnswerStatus
 ) : BaseUUIDEntity(id)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/model/Inquiry.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/model/Inquiry.kt
@@ -20,8 +20,11 @@ class Inquiry(
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User,
 
-    @Column(columnDefinition = "VARCHAR(1000)", nullable = false)
+    @Column(columnDefinition = "VARCHAR(100)", nullable = false)
     val question: String,
+
+    @Column(columnDefinition = "VARCHAR(1000)", nullable = false)
+    val questionDetail: String,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "answer_status", nullable = false)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/model/Inquiry.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/model/Inquiry.kt
@@ -4,8 +4,11 @@ import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
 import team.msg.common.entity.BaseUUIDEntity
 import team.msg.domain.inquiry.enums.AnswerStatus
+import team.msg.domain.user.model.User
 import java.util.*
 
 @Entity
@@ -13,8 +16,9 @@ class Inquiry(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
-    @Column(name = "user_id", columnDefinition = "BINARY(16)", nullable = false)
-    val userId: UUID,
+    @ManyToOne
+    @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
+    val user: User,
 
     @Column(columnDefinition = "VARCHAR(1000)", nullable = false)
     val question: String,

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/model/InquiryAnswer.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/model/InquiryAnswer.kt
@@ -2,8 +2,10 @@ package team.msg.domain.inquiry.model
 
 import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import team.msg.common.entity.BaseUUIDEntity
+import team.msg.domain.user.model.User
 import java.util.*
 
 @Entity
@@ -14,8 +16,9 @@ class InquiryAnswer(
     @Column(columnDefinition = "VARCHAR(500)", nullable = false)
     val answer: String,
 
-    @Column(name = "user_id", columnDefinition = "BINARY(16)", nullable = false)
-    val adminId: UUID,
+    @ManyToOne
+    @JoinColumn(name = "admin_id", columnDefinition = "BINARY(16)", nullable = false)
+    val admin: User,
 
     @Column(name = "inquiry_id", columnDefinition = "BINARY(16)", nullable = false)
     val inquiryId: UUID

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/InquiryRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/InquiryRepository.kt
@@ -1,8 +1,12 @@
 package team.msg.domain.inquiry.repository
 
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.inquiry.model.Inquiry
+import team.msg.domain.user.model.User
 import java.util.UUID
 
 interface InquiryRepository : CrudRepository<Inquiry, UUID> {
+    @EntityGraph(attributePaths = ["user"], type = EntityGraph.EntityGraphType.FETCH)
+    fun findByUser(user: User): List<Inquiry>
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/InquiryRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/InquiryRepository.kt
@@ -3,10 +3,11 @@ package team.msg.domain.inquiry.repository
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.inquiry.model.Inquiry
+import team.msg.domain.inquiry.repository.custom.InquiryRepositoryCustom
 import team.msg.domain.user.model.User
 import java.util.UUID
 
-interface InquiryRepository : CrudRepository<Inquiry, UUID> {
+interface InquiryRepository : CrudRepository<Inquiry, UUID>, InquiryRepositoryCustom {
     @EntityGraph(attributePaths = ["user"], type = EntityGraph.EntityGraphType.FETCH)
     fun findByUser(user: User): List<Inquiry>
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/custom/InquiryRepositoryCustom.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/custom/InquiryRepositoryCustom.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.inquiry.repository.custom
+
+import team.msg.domain.inquiry.enums.AnswerStatus
+import team.msg.domain.inquiry.model.Inquiry
+
+interface InquiryRepositoryCustom {
+    fun search(answerStatus: AnswerStatus?, keyword: String): List<Inquiry>
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/custom/InquiryRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/custom/InquiryRepositoryImpl.kt
@@ -13,9 +13,16 @@ class InquiryRepositoryImpl(
 ) : InquiryRepositoryCustom {
 
     override fun search(answerStatus: AnswerStatus?, keyword: String): List<Inquiry> {
-        TODO("Not yet implemented")
+        return jpaQueryFactory.selectFrom(inquiry)
+            .where(
+                answerStatusEq(answerStatus),
+                keywordLike(keyword)
+            ).fetch()
     }
 
+    private fun answerStatusEq(answerStatus: AnswerStatus?): BooleanExpression? =
+        if(answerStatus == null) null else inquiry.answerStatus.eq(answerStatus)
+
     private fun keywordLike(keyword: String): BooleanExpression? =
-        if(keyword == "") null else inquiry.question.like("%$keyword%")
+        if(keyword == "") null else inquiry.questionDetail.like("%$keyword%")
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/custom/InquiryRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/custom/InquiryRepositoryImpl.kt
@@ -24,5 +24,5 @@ class InquiryRepositoryImpl(
         if(answerStatus == null) null else inquiry.answerStatus.eq(answerStatus)
 
     private fun keywordLike(keyword: String): BooleanExpression? =
-        if(keyword == "") null else inquiry.questionDetail.like("%$keyword%")
+        if(keyword == "") null else inquiry.question.like("%$keyword%")
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/custom/InquiryRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/custom/InquiryRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package team.msg.domain.inquiry.repository.custom
+
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+import team.msg.domain.inquiry.enums.AnswerStatus
+import team.msg.domain.inquiry.model.Inquiry
+import team.msg.domain.inquiry.model.QInquiry.inquiry
+
+@Repository
+class InquiryRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+) : InquiryRepositoryCustom {
+
+    override fun search(answerStatus: AnswerStatus?, keyword: String): List<Inquiry> {
+        TODO("Not yet implemented")
+    }
+
+    private fun keywordLike(keyword: String): BooleanExpression? =
+        if(keyword == "") null else inquiry.question.like("%$keyword%")
+}

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/UserRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/UserRepository.kt
@@ -5,7 +5,7 @@ import team.msg.domain.user.model.User
 import team.msg.domain.user.repository.custom.CustomUserRepository
 import java.util.UUID
 
-interface UserRepository : CrudRepository<User, UUID>,CustomUserRepository {
+interface UserRepository : CrudRepository<User, UUID>, CustomUserRepository {
     fun existsByEmail(email: String): Boolean
     fun existsByPhoneNumber(phoneNumber: String): Boolean
     fun findByEmail(email: String): User?

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/custom/impl/CustomUserRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/custom/impl/CustomUserRepositoryImpl.kt
@@ -58,8 +58,9 @@ class CustomUserRepositoryImpl(
             .where(user.id.eq(id))
             .from(user)
             .fetchOne()
+
     private fun nameLike(keyword: String): BooleanExpression? =
-        if(keyword == "") null else user.name.like(keyword)
+        if(keyword == "") null else user.name.like("%$keyword%")
 
     private fun authorityEq(authority: Authority): BooleanExpression? =
         if(authority == Authority.ROLE_USER) null else user.authority.eq(authority)


### PR DESCRIPTION
## 💡 개요
- 문의사항 조희 어드민 API
- 문의사항 조회 유저 API

## 📃 작업내용
문의사항 조회 API를 개발했어요

문의사항에 질문, 질문상세로 분리했고 userId참조에서 그냥 ManyToOne으로 다시 바꿨습니다.
그 이유가 listOf 구현하면서 유저 네임하고 문의사항하고 같이 넘겨줘야했는데 그냥 매핑하기보다는
객체 탐색으로 편하게 구현하려구요

그리고 검색 기능을 구현하면서 user 검색 기능에서 keyword Like에 %옵션이 없더라구요 추가했습니다.

## 🔀 변경사항
- UserRepositoryCustom
- Inquiry

## 🎸 기타
[depapepe - START](https://www.youtube.com/results?search_query=start+depapepe) 이 기타곡 좋습니다.
