### PR TITLE
# 217 동아리 조회 관련 API 분리

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
@@ -39,8 +39,14 @@ class ClubController(
     }
 
     @GetMapping("/{id}/member")
-    fun queryUserByClubId(@PathVariable id: Long): ResponseEntity<AllStudentsResponse> {
+    fun queryUsersByClubId(@PathVariable id: Long): ResponseEntity<AllStudentsResponse> {
         val response = clubService.queryAllStudentsByClubId(id)
+        return ResponseEntity.status(HttpStatus.OK).body(response)
+    }
+
+    @GetMapping("/my/member")
+    fun queryUsersByMyClub(): ResponseEntity<AllStudentsResponse> {
+        val response = clubService.queryAllStudentsByMyClub()
         return ResponseEntity.status(HttpStatus.OK).body(response)
     }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
@@ -32,6 +32,12 @@ class ClubController(
         return ResponseEntity.status(HttpStatus.OK).body(response)
     }
 
+    @GetMapping("/my")
+    fun queryMyClubDetails(): ResponseEntity<ClubDetailsResponse> {
+        val response = clubService.queryMyClubDetailsService()
+        return ResponseEntity.status(HttpStatus.OK).body(response)
+    }
+
     @GetMapping("/{id}/member")
     fun queryUserByClubId(@PathVariable id: Long): ResponseEntity<AllStudentsResponse> {
         val response = clubService.queryAllStudentsByClubId(id)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
@@ -4,13 +4,15 @@ import team.msg.domain.club.model.Club
 
 data class ClubResponse(
     val id: Long,
-    val name: String
+    val name: String,
+    val schoolName: String
 ) {
     companion object {
         fun listOf(clubs: List<Club>): List<ClubResponse> = clubs.map {
             ClubResponse(
                 id = it.id,
-                name = it.name
+                name = it.name,
+                schoolName = it.school.highSchool.schoolName
             )
         }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
@@ -12,5 +12,6 @@ interface ClubService {
     fun queryClubDetailsService(id: Long): ClubDetailsResponse
     fun queryMyClubDetailsService(): ClubDetailsResponse
     fun queryAllStudentsByClubId(id: Long): AllStudentsResponse
+    fun queryAllStudentsByMyClub(): AllStudentsResponse
     fun queryStudentDetails(clubId: Long, studentId: UUID): StudentDetailsResponse
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
@@ -10,6 +10,7 @@ import java.util.UUID
 interface ClubService {
     fun queryAllClubsService(highSchool: HighSchool): ClubsResponse
     fun queryClubDetailsService(id: Long): ClubDetailsResponse
+    fun queryMyClubDetailsService(): ClubDetailsResponse
     fun queryAllStudentsByClubId(id: Long): AllStudentsResponse
     fun queryStudentDetails(clubId: Long, studentId: UUID): StudentDetailsResponse
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
@@ -80,7 +80,7 @@ class ClubServiceImpl(
     }
 
     /**
-     * 동아리를의 학생 리스트를 조회하는 비즈니스 로직
+     * 동아리의 학생 리스트를 조회하는 비즈니스 로직
      * @param 동아리에 속한 학생 리스트를 조회하기 위한 id
      * @return 동아리에 속한 학생 리스트를 담은 dto
      */
@@ -90,6 +90,26 @@ class ClubServiceImpl(
             ?: throw ClubNotFoundException("존재하지 않는 동아리 입니다. info : [ clubId = $id ]")
 
         val students = studentRepository.findAllByClub(club)
+
+        val response = AllStudentsResponse(
+            StudentResponse.listOf(students)
+        )
+
+        return response
+    }
+
+    /**
+     * 동아리의 학생 리스트를 조회하는 비즈니스 로직
+     * @return 동아리에 속한 학생 리스트를 담은 dto
+     */
+    @Transactional(readOnly = true)
+    override fun queryAllStudentsByMyClub(): AllStudentsResponse {
+        val user = userUtil.queryCurrentUser()
+
+        val student = studentRepository.findByUser(user)
+            ?: throw StudentNotFoundException("존재하지 않는 학생입니다. info : [ userId = ${user.id} ]")
+
+        val students = studentRepository.findAllByClub(student.club)
 
         val response = AllStudentsResponse(
             StudentResponse.listOf(students)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
@@ -3,6 +3,7 @@ package team.msg.domain.club.service
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.msg.common.util.UserUtil
 import team.msg.domain.club.exception.ClubNotFoundException
 import team.msg.domain.club.presentation.data.response.*
 import team.msg.domain.club.repository.ClubRepository
@@ -20,7 +21,8 @@ import java.util.*
 class ClubServiceImpl(
     private val clubRepository: ClubRepository,
     private val schoolRepository: SchoolRepository,
-    private val studentRepository: StudentRepository
+    private val studentRepository: StudentRepository,
+    private val userUtil: UserUtil
 ) : ClubService {
 
     /**
@@ -55,6 +57,24 @@ class ClubServiceImpl(
         val headCount = studentRepository.countByClub(club).toInt()
 
         val response = ClubResponse.detailOf(club, headCount)
+
+        return response
+    }
+
+    /**
+     * 자신이 속한 동아리를 상세 조회하는 비즈니스 로직
+     * @return 동아리 상세 정보를 담은 dto
+     */
+    @Transactional(readOnly = true)
+    override fun queryMyClubDetailsService(): ClubDetailsResponse {
+        val user = userUtil.queryCurrentUser()
+
+        val student = studentRepository.findByUser(user)
+            ?: throw StudentNotFoundException("존재하지 않는 학생입니다. info : [ userId = ${user.id} ]")
+
+        val headCount = studentRepository.countByClub(student.club).toInt()
+
+        val response = ClubResponse.detailOf(student.club, headCount)
 
         return response
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
@@ -9,8 +9,6 @@ import team.msg.domain.inquiry.presentation.request.CreateInquiryRequest
 import team.msg.domain.inquiry.presentation.response.InquiryResponse
 import team.msg.domain.inquiry.presentation.response.InquiryResponses
 import team.msg.domain.inquiry.repository.InquiryRepository
-import team.msg.domain.user.exception.UserNotFoundException
-import team.msg.domain.user.repository.UserRepository
 import java.util.*
 
 @Service
@@ -47,7 +45,7 @@ class InquiryServiceImpl(
     override fun queryMyInquiries(): InquiryResponses {
         val currentUser = userUtil.queryCurrentUser()
 
-        val inquiries = inquiryRepository.findByUser(currentUser)
+        val inquiries = inquiryRepository.findAllByUser(currentUser)
 
         return InquiryResponse.listOf(inquiries)
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -64,8 +64,9 @@ class SecurityConfig(
             // club
             .mvcMatchers(HttpMethod.GET, "/club").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/club/{id}").hasAnyRole(ADMIN)
-            .mvcMatchers(HttpMethod.GET, "/club/my").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
-            .mvcMatchers(HttpMethod.GET, "/club/{id}/member").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
+            .mvcMatchers(HttpMethod.GET, "/club/my").hasAnyRole(STUDENT, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
+            .mvcMatchers(HttpMethod.GET, "/club/{id}/member").hasAnyRole(ADMIN)
+            .mvcMatchers(HttpMethod.GET, "/club/my/member").hasAnyRole(STUDENT, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
             .mvcMatchers(HttpMethod.GET, "/club/{id}/{student_id}").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
 
             // activity

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -63,7 +63,8 @@ class SecurityConfig(
 
             // club
             .mvcMatchers(HttpMethod.GET, "/club").hasRole(ADMIN)
-            .mvcMatchers(HttpMethod.GET, "/club/{id}").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
+            .mvcMatchers(HttpMethod.GET, "/club/{id}").hasAnyRole(ADMIN)
+            .mvcMatchers(HttpMethod.GET, "/club/my").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
             .mvcMatchers(HttpMethod.GET, "/club/{id}/member").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
             .mvcMatchers(HttpMethod.GET, "/club/{id}/{student_id}").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
 

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/InquiryRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/InquiryRepository.kt
@@ -9,5 +9,5 @@ import java.util.UUID
 
 interface InquiryRepository : CrudRepository<Inquiry, UUID>, InquiryRepositoryCustom {
     @EntityGraph(attributePaths = ["user"], type = EntityGraph.EntityGraphType.FETCH)
-    fun findByUser(user: User): List<Inquiry>
+    fun findAllByUser(user: User): List<Inquiry>
 }


### PR DESCRIPTION
## 💡 개요
동아리 조회 관련 API 분리
## 📃 작업내용
* 동아리 Id를 이용한 동아리 상세 조회 기능의 접근 권한을 수정 해주었습니다.
* * 동아리 Id를 이용한 동아리원 상세 조회 기능 접근 권한을 수정 해주었습니다.
* 자신이 속한 동아리 조회 API를 개발했습니다.
* 자신이 속한 동아리 소속 유저 리스트 조회 API를 개발했습니다.

### 다시 확인 해주세요!
* 동아리 전체 조회에 학교 이름 추가 반환
