### PR TITLE
# 219 동아리 상세 조회 및 동아리 부원 조회 API 병합

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
@@ -2,18 +2,13 @@ package team.msg.domain.club.presentation
 
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
-import team.msg.domain.club.presentation.data.response.ClubsResponse
+import org.springframework.web.bind.annotation.*
 import team.msg.domain.club.presentation.data.response.ClubDetailsResponse
+import team.msg.domain.club.presentation.data.response.ClubsResponse
 import team.msg.domain.club.service.ClubService
 import team.msg.domain.school.enums.HighSchool
-import team.msg.domain.student.presentation.data.response.AllStudentsResponse
 import team.msg.domain.student.presentation.data.response.StudentDetailsResponse
-import java.util.UUID
+import java.util.*
 
 @RestController
 @RequestMapping("/club")
@@ -28,25 +23,13 @@ class ClubController(
 
     @GetMapping("/{id}")
     fun queryClubDetails(@PathVariable id: Long): ResponseEntity<ClubDetailsResponse> {
-        val response = clubService.queryClubDetailsService(id)
+        val response = clubService.queryClubDetailsByIdService(id)
         return ResponseEntity.status(HttpStatus.OK).body(response)
     }
 
     @GetMapping("/my")
     fun queryMyClubDetails(): ResponseEntity<ClubDetailsResponse> {
         val response = clubService.queryMyClubDetailsService()
-        return ResponseEntity.status(HttpStatus.OK).body(response)
-    }
-
-    @GetMapping("/{id}/member")
-    fun queryUsersByClubId(@PathVariable id: Long): ResponseEntity<AllStudentsResponse> {
-        val response = clubService.queryAllStudentsByClubId(id)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
-    }
-
-    @GetMapping("/my/member")
-    fun queryUsersByMyClub(): ResponseEntity<AllStudentsResponse> {
-        val response = clubService.queryAllStudentsByMyClub()
         return ResponseEntity.status(HttpStatus.OK).body(response)
     }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
@@ -1,6 +1,7 @@
 package team.msg.domain.club.presentation.data.response
 
 import team.msg.domain.club.model.Club
+import team.msg.domain.school.model.School
 import team.msg.domain.student.model.Student
 import team.msg.domain.student.presentation.data.response.StudentResponse
 
@@ -30,6 +31,13 @@ data class ClubResponse(
                 )
             }
         )
+
+        fun schoolOf(clubs: List<Club>) = clubs.map {
+            SchoolToClubResponse(
+                id = it.id,
+                name = it.name
+            )
+        }
     }
 }
 
@@ -42,4 +50,9 @@ data class ClubDetailsResponse(
     val highSchoolName: String,
     val headCount: Int,
     val students: List<StudentResponse>
+)
+
+data class SchoolToClubResponse(
+    val id: Long,
+    val name: String
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/data/response/ClubResponse.kt
@@ -1,6 +1,8 @@
 package team.msg.domain.club.presentation.data.response
 
 import team.msg.domain.club.model.Club
+import team.msg.domain.student.model.Student
+import team.msg.domain.student.presentation.data.response.StudentResponse
 
 data class ClubResponse(
     val id: Long,
@@ -16,10 +18,17 @@ data class ClubResponse(
             )
         }
 
-        fun detailOf(club: Club, headCount: Int) = ClubDetailsResponse(
+        fun detailOf(club: Club, headCount: Int, students: List<Student>) = ClubDetailsResponse(
             clubName = club.name,
             highSchoolName = club.school.highSchool.schoolName,
-            headCount = headCount
+            headCount = headCount,
+            students = students.map {
+                StudentResponse(
+                    id = it.id,
+                    name = it.user!!.name,
+                    authority = it.user!!.authority
+                )
+            }
         )
     }
 }
@@ -31,5 +40,6 @@ data class ClubsResponse(
 data class ClubDetailsResponse(
     val clubName: String,
     val highSchoolName: String,
-    val headCount: Int
+    val headCount: Int,
+    val students: List<StudentResponse>
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubService.kt
@@ -1,17 +1,14 @@
 package team.msg.domain.club.service
 
-import team.msg.domain.club.presentation.data.response.ClubsResponse
 import team.msg.domain.club.presentation.data.response.ClubDetailsResponse
+import team.msg.domain.club.presentation.data.response.ClubsResponse
 import team.msg.domain.school.enums.HighSchool
-import team.msg.domain.student.presentation.data.response.AllStudentsResponse
 import team.msg.domain.student.presentation.data.response.StudentDetailsResponse
-import java.util.UUID
+import java.util.*
 
 interface ClubService {
     fun queryAllClubsService(highSchool: HighSchool): ClubsResponse
-    fun queryClubDetailsService(id: Long): ClubDetailsResponse
+    fun queryClubDetailsByIdService(id: Long): ClubDetailsResponse
     fun queryMyClubDetailsService(): ClubDetailsResponse
-    fun queryAllStudentsByClubId(id: Long): AllStudentsResponse
-    fun queryAllStudentsByMyClub(): AllStudentsResponse
     fun queryStudentDetails(clubId: Long, studentId: UUID): StudentDetailsResponse
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
@@ -5,24 +5,30 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.msg.common.util.UserUtil
 import team.msg.domain.bbozzak.exception.BbozzakNotFoundException
+import team.msg.domain.bbozzak.model.Bbozzak
 import team.msg.domain.bbozzak.repository.BbozzakRepository
 import team.msg.domain.club.exception.ClubNotFoundException
 import team.msg.domain.club.presentation.data.response.*
 import team.msg.domain.club.repository.ClubRepository
 import team.msg.domain.company.exception.CompanyNotFoundException
+import team.msg.domain.company.model.CompanyInstructor
 import team.msg.domain.company.repository.CompanyInstructorRepository
 import team.msg.domain.government.GovernmentNotFoundException
+import team.msg.domain.government.model.Government
 import team.msg.domain.government.repository.GovernmentRepository
 import team.msg.domain.professor.exception.ProfessorNotFoundException
+import team.msg.domain.professor.model.Professor
 import team.msg.domain.professor.repository.ProfessorRepository
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.school.exception.SchoolNotFoundException
 import team.msg.domain.school.repository.SchoolRepository
 import team.msg.domain.student.exception.StudentNotFoundException
+import team.msg.domain.student.model.Student
 import team.msg.domain.student.presentation.data.response.StudentDetailsResponse
 import team.msg.domain.student.presentation.data.response.StudentResponse
 import team.msg.domain.student.repository.StudentRepository
 import team.msg.domain.teacher.exception.TeacherNotFoundException
+import team.msg.domain.teacher.model.Teacher
 import team.msg.domain.teacher.repository.TeacherRepository
 import team.msg.domain.user.enums.Authority
 import team.msg.domain.user.model.User
@@ -86,14 +92,16 @@ class ClubServiceImpl(
     override fun queryMyClubDetailsService(): ClubDetailsResponse {
         val user = userUtil.queryCurrentUser()
 
-        val club = when (user.authority) {
-            Authority.ROLE_TEACHER -> findTeacherByUser(user).club
-            Authority.ROLE_STUDENT -> findStudentByUser(user).club
-            Authority.ROLE_BBOZZAK -> findBbozzakByUser(user).club
-            Authority.ROLE_PROFESSOR -> findProfessorByUser(user).club
-            Authority.ROLE_COMPANY_INSTRUCTOR -> findCompanyInstructorByUser(user).club
-            Authority.ROLE_GOVERNMENT -> findGovernmentByUser(user).club
-            else -> throw InvalidRoleException("유효하지 않은 권한입니다. info : [ userAuthority = ${user.authority}]")
+        val entity = userUtil.getAuthorityEntityAndOrganization(user).first
+
+        val club = when(entity) {
+            is Student -> findTeacherByUser(user).club
+            is Teacher -> findStudentByUser(user).club
+            is Bbozzak -> findBbozzakByUser(user).club
+            is Professor -> findProfessorByUser(user).club
+            is CompanyInstructor -> findCompanyInstructorByUser(user).club
+            is Government -> findGovernmentByUser(user).club
+            else ->  throw InvalidRoleException("유효하지 않은 권한입니다. info : [ userAuthority = ${user.authority} ]")
         }
 
         val students = studentRepository.findAllByClub(club)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/service/ClubServiceImpl.kt
@@ -4,17 +4,29 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.msg.common.util.UserUtil
+import team.msg.domain.bbozzak.exception.BbozzakNotFoundException
+import team.msg.domain.bbozzak.repository.BbozzakRepository
 import team.msg.domain.club.exception.ClubNotFoundException
 import team.msg.domain.club.presentation.data.response.*
 import team.msg.domain.club.repository.ClubRepository
+import team.msg.domain.company.exception.CompanyNotFoundException
+import team.msg.domain.company.repository.CompanyInstructorRepository
+import team.msg.domain.government.GovernmentNotFoundException
+import team.msg.domain.government.repository.GovernmentRepository
+import team.msg.domain.professor.exception.ProfessorNotFoundException
+import team.msg.domain.professor.repository.ProfessorRepository
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.school.exception.SchoolNotFoundException
 import team.msg.domain.school.repository.SchoolRepository
 import team.msg.domain.student.exception.StudentNotFoundException
-import team.msg.domain.student.presentation.data.response.AllStudentsResponse
 import team.msg.domain.student.presentation.data.response.StudentDetailsResponse
 import team.msg.domain.student.presentation.data.response.StudentResponse
 import team.msg.domain.student.repository.StudentRepository
+import team.msg.domain.teacher.exception.TeacherNotFoundException
+import team.msg.domain.teacher.repository.TeacherRepository
+import team.msg.domain.user.enums.Authority
+import team.msg.domain.user.model.User
+import team.msg.global.exception.InvalidRoleException
 import java.util.*
 
 @Service
@@ -22,7 +34,12 @@ class ClubServiceImpl(
     private val clubRepository: ClubRepository,
     private val schoolRepository: SchoolRepository,
     private val studentRepository: StudentRepository,
-    private val userUtil: UserUtil
+    private val userUtil: UserUtil,
+    private val teacherRepository: TeacherRepository,
+    private val bbozzakRepository: BbozzakRepository,
+    private val professorRepository: ProfessorRepository,
+    private val companyInstructorRepository: CompanyInstructorRepository,
+    private val governmentRepository: GovernmentRepository
 ) : ClubService {
 
     /**
@@ -50,70 +67,38 @@ class ClubServiceImpl(
      * @return 동아리 상세 정보를 담은 dto
      */
     @Transactional(readOnly = true)
-    override fun queryClubDetailsService(id: Long): ClubDetailsResponse {
+    override fun queryClubDetailsByIdService(id: Long): ClubDetailsResponse {
         val club = clubRepository.findByIdOrNull(id)
             ?: throw ClubNotFoundException("존재하지 않는 동아리 입니다. info : [ clubId = $id ]")
 
-        val headCount = studentRepository.countByClub(club).toInt()
+        val students = studentRepository.findAllByClub(club)
 
-        val response = ClubResponse.detailOf(club, headCount)
+        val response = ClubResponse.detailOf(club, students.size, students)
 
         return response
     }
 
     /**
-     * 자신이 속한 동아리를 상세 조회하는 비즈니스 로직
+     * 동아리를 상세 조회하는 비즈니스 로직
      * @return 동아리 상세 정보를 담은 dto
      */
     @Transactional(readOnly = true)
     override fun queryMyClubDetailsService(): ClubDetailsResponse {
         val user = userUtil.queryCurrentUser()
 
-        val student = studentRepository.findByUser(user)
-            ?: throw StudentNotFoundException("존재하지 않는 학생입니다. info : [ userId = ${user.id} ]")
-
-        val headCount = studentRepository.countByClub(student.club).toInt()
-
-        val response = ClubResponse.detailOf(student.club, headCount)
-
-        return response
-    }
-
-    /**
-     * 동아리의 학생 리스트를 조회하는 비즈니스 로직
-     * @param 동아리에 속한 학생 리스트를 조회하기 위한 id
-     * @return 동아리에 속한 학생 리스트를 담은 dto
-     */
-    @Transactional(readOnly = true)
-    override fun queryAllStudentsByClubId(id: Long): AllStudentsResponse {
-        val club = clubRepository.findByIdOrNull(id)
-            ?: throw ClubNotFoundException("존재하지 않는 동아리 입니다. info : [ clubId = $id ]")
+        val club = when (user.authority) {
+            Authority.ROLE_TEACHER -> findTeacherByUser(user).club
+            Authority.ROLE_STUDENT -> findStudentByUser(user).club
+            Authority.ROLE_BBOZZAK -> findBbozzakByUser(user).club
+            Authority.ROLE_PROFESSOR -> findProfessorByUser(user).club
+            Authority.ROLE_COMPANY_INSTRUCTOR -> findCompanyInstructorByUser(user).club
+            Authority.ROLE_GOVERNMENT -> findGovernmentByUser(user).club
+            else -> throw InvalidRoleException("유효하지 않은 권한입니다. info : [ userAuthority = ${user.authority}]")
+        }
 
         val students = studentRepository.findAllByClub(club)
 
-        val response = AllStudentsResponse(
-            StudentResponse.listOf(students)
-        )
-
-        return response
-    }
-
-    /**
-     * 동아리의 학생 리스트를 조회하는 비즈니스 로직
-     * @return 동아리에 속한 학생 리스트를 담은 dto
-     */
-    @Transactional(readOnly = true)
-    override fun queryAllStudentsByMyClub(): AllStudentsResponse {
-        val user = userUtil.queryCurrentUser()
-
-        val student = studentRepository.findByUser(user)
-            ?: throw StudentNotFoundException("존재하지 않는 학생입니다. info : [ userId = ${user.id} ]")
-
-        val students = studentRepository.findAllByClub(student.club)
-
-        val response = AllStudentsResponse(
-            StudentResponse.listOf(students)
-        )
+        val response = ClubResponse.detailOf(club, students.size, students)
 
         return response
     }
@@ -135,4 +120,23 @@ class ClubServiceImpl(
 
         return response
     }
+
+    private fun findStudentByUser(user: User) = studentRepository.findByUser(user)
+        ?: throw StudentNotFoundException("학생을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+
+    private fun findTeacherByUser(user: User) = teacherRepository.findByUser(user)
+        ?: throw TeacherNotFoundException("취업 동아리 선생님을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+
+    private fun findBbozzakByUser(user: User) = bbozzakRepository.findByUser(user)
+        ?: throw BbozzakNotFoundException("뽀짝 선생님을 찾을 수 없습니다.  info : [ userId = ${user.id} ]")
+
+    private fun findProfessorByUser(user: User) = professorRepository.findByUser(user)
+        ?: throw ProfessorNotFoundException("대학 교수를 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+
+    private fun findCompanyInstructorByUser(user: User) = companyInstructorRepository.findByUser(user)
+        ?: throw CompanyNotFoundException("기업 강사를 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+
+    private fun findGovernmentByUser(user: User) = governmentRepository.findByUser(user)
+        ?: throw GovernmentNotFoundException("유관기관을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/school/presentation/SchoolController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/school/presentation/SchoolController.kt
@@ -1,0 +1,21 @@
+package team.msg.domain.school.presentation
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import team.msg.domain.school.presentation.data.response.SchoolsResponse
+import team.msg.domain.school.service.SchoolService
+
+@RestController
+@RequestMapping("/school")
+class SchoolController(
+    private val schoolService: SchoolService
+) {
+    @GetMapping
+    fun querySchools(): ResponseEntity<SchoolsResponse> {
+        val response = schoolService.querySchoolsService()
+        return ResponseEntity.status(HttpStatus.OK).body(response)
+    }
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/school/presentation/data/response/SchoolResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/school/presentation/data/response/SchoolResponse.kt
@@ -1,13 +1,13 @@
 package team.msg.domain.school.presentation.data.response
 
-import team.msg.domain.club.model.Club
+import team.msg.domain.club.presentation.data.response.SchoolToClubResponse
 
 data class SchoolResponse(
     val id: Long,
     val schoolName: String,
-    val clubs: List<Club>
+    val clubs: List<SchoolToClubResponse>
 )
 
 data class SchoolsResponse(
-    val school: List<SchoolResponse>
+    val schools: List<SchoolResponse>
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/school/presentation/data/response/SchoolResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/school/presentation/data/response/SchoolResponse.kt
@@ -1,0 +1,13 @@
+package team.msg.domain.school.presentation.data.response
+
+import team.msg.domain.club.model.Club
+
+data class SchoolResponse(
+    val id: Long,
+    val schoolName: String,
+    val clubs: List<Club>
+)
+
+data class SchoolsResponse(
+    val school: List<SchoolResponse>
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/school/service/SchoolService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/school/service/SchoolService.kt
@@ -1,0 +1,7 @@
+package team.msg.domain.school.service
+
+import team.msg.domain.school.presentation.data.response.SchoolsResponse
+
+interface SchoolService {
+    fun querySchoolsService(): SchoolsResponse
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/school/service/SchoolServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/school/service/SchoolServiceImpl.kt
@@ -1,0 +1,36 @@
+package team.msg.domain.school.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.msg.domain.club.repository.ClubRepository
+import team.msg.domain.school.presentation.data.response.SchoolResponse
+import team.msg.domain.school.presentation.data.response.SchoolsResponse
+import team.msg.domain.school.repository.SchoolRepository
+
+@Service
+class SchoolServiceImpl(
+    private val schoolRepository: SchoolRepository,
+    private val clubRepository: ClubRepository
+) : SchoolService {
+
+    /**
+     * 학교를 전체 조회하는 비즈니스 로직
+     * @return 학교의 정보를 담은 dto
+     */
+    @Transactional(readOnly = true)
+    override fun querySchoolsService(): SchoolsResponse {
+        val schools = schoolRepository.findAll()
+
+        val response = SchoolsResponse(
+            school = schools.map {
+                SchoolResponse(
+                    id = it.id,
+                    schoolName = it.highSchool.schoolName,
+                    clubs = clubRepository.findAllBySchool(it)
+                )
+            }
+        )
+
+        return response
+    }
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/school/service/SchoolServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/school/service/SchoolServiceImpl.kt
@@ -2,6 +2,8 @@ package team.msg.domain.school.service
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.msg.domain.club.presentation.data.response.ClubResponse
+import team.msg.domain.club.presentation.data.response.SchoolToClubResponse
 import team.msg.domain.club.repository.ClubRepository
 import team.msg.domain.school.presentation.data.response.SchoolResponse
 import team.msg.domain.school.presentation.data.response.SchoolsResponse
@@ -22,11 +24,12 @@ class SchoolServiceImpl(
         val schools = schoolRepository.findAll()
 
         val response = SchoolsResponse(
-            school = schools.map {
+            schools = schools.map {
+                val clubs = clubRepository.findAllBySchool(it)
                 SchoolResponse(
                     id = it.id,
                     schoolName = it.highSchool.schoolName,
-                    clubs = clubRepository.findAllBySchool(it)
+                    clubs = ClubResponse.schoolOf(clubs)
                 )
             }
         )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentResponse.kt
@@ -27,10 +27,6 @@ class StudentResponse(
     }
 }
 
-data class AllStudentsResponse(
-    val students: List<StudentResponse>
-)
-
 data class StudentDetailsResponse(
     val name: String,
     val phoneNumber: String,

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -63,10 +63,8 @@ class SecurityConfig(
 
             // club
             .mvcMatchers(HttpMethod.GET, "/club").hasRole(ADMIN)
-            .mvcMatchers(HttpMethod.GET, "/club/{id}").hasAnyRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/club/my").hasAnyRole(STUDENT, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
-            .mvcMatchers(HttpMethod.GET, "/club/{id}/member").hasAnyRole(ADMIN)
-            .mvcMatchers(HttpMethod.GET, "/club/my/member").hasAnyRole(STUDENT, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
+            .mvcMatchers(HttpMethod.GET, "/club/{id}").hasAnyRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/club/{id}/{student_id}").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
 
             // activity

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -67,6 +67,8 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.GET, "/club/{id}").hasAnyRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/club/{id}/{student_id}").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
 
+            .mvcMatchers(HttpMethod.GET, "/school").authenticated()
+
             // activity
             .mvcMatchers(HttpMethod.POST, "/activity").hasRole(STUDENT)
             .mvcMatchers(HttpMethod.PATCH, "/activity/{id}").hasRole(STUDENT)
@@ -107,7 +109,7 @@ class SecurityConfig(
             // user
             .mvcMatchers(HttpMethod.GET, "/user").authenticated()
 
-            //admin
+            // admin
             .mvcMatchers(HttpMethod.GET, "/admin").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.PATCH, "/admin/{user_id}").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.DELETE, "/admin/{user_id}").hasRole(ADMIN)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/StudentRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/StudentRepository.kt
@@ -15,6 +15,5 @@ interface StudentRepository : CrudRepository<Student, UUID> {
     fun findStudentById(id: UUID): Student?
     @EntityGraph(attributePaths = ["user"], type = EntityGraph.EntityGraphType.FETCH)
     fun findByIdAndClub(id: UUID, club: Club): Student?
-    fun countByClub(club: Club): Long
     fun findAllByClub(club: Club): List<Student>
 }


### PR DESCRIPTION
## 💡 개요
동아리 상세 조회 및 동아리 부원 조회 API 병합
## 📃 작업내용
동아리 상세 조회 및 동아리 부원 조회 API를 병합 해주었습니다.(어드민용 / 동아리에 소속된 유저용 으로 나누어 작업 했습니다.)
headCount를 쿼리를 날리는 대신 size를 이용해 바꾸어 주었습니다.
student 반환은 StudentResponse 클래스를 이용해 주었습니다.