### PR TITLE
234 feature/fix admin query inquiry

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/mapper/InquiryMapper.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/mapper/InquiryMapper.kt
@@ -5,10 +5,13 @@ import team.msg.domain.inquiry.presentation.request.CreateInquiryRequest
 import team.msg.domain.inquiry.presentation.request.UpdateInquiryRequest
 import team.msg.domain.inquiry.presentation.web.CreateInquiryAnswerWebRequest
 import team.msg.domain.inquiry.presentation.web.CreateInquiryWebRequest
+import team.msg.domain.inquiry.presentation.request.QueryAllInquiresWebRequest
+import team.msg.domain.inquiry.presentation.web.QueryAllInquiresRequest
 import team.msg.domain.inquiry.presentation.web.UpdateInquiryWebRequest
 
 interface InquiryMapper {
     fun createInquiryWebRequestToDto(webRequest: CreateInquiryWebRequest): CreateInquiryRequest
     fun updateInquiryWebRequestToDto(webRequest: UpdateInquiryWebRequest): UpdateInquiryRequest
     fun createInquiryAnswerWebRequestToDto(webRequest: CreateInquiryAnswerWebRequest): CreateInquiryAnswerRequest
+    fun queryAllInquiresWebRequestToDto(webRequest: QueryAllInquiresWebRequest): QueryAllInquiresRequest
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/mapper/InquiryMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/mapper/InquiryMapperImpl.kt
@@ -3,9 +3,11 @@ package team.msg.domain.inquiry.mapper
 import org.springframework.stereotype.Component
 import team.msg.domain.inquiry.presentation.request.CreateInquiryAnswerRequest
 import team.msg.domain.inquiry.presentation.request.CreateInquiryRequest
+import team.msg.domain.inquiry.presentation.request.QueryAllInquiresWebRequest
 import team.msg.domain.inquiry.presentation.request.UpdateInquiryRequest
 import team.msg.domain.inquiry.presentation.web.CreateInquiryAnswerWebRequest
 import team.msg.domain.inquiry.presentation.web.CreateInquiryWebRequest
+import team.msg.domain.inquiry.presentation.web.QueryAllInquiresRequest
 import team.msg.domain.inquiry.presentation.web.UpdateInquiryWebRequest
 
 @Component
@@ -25,6 +27,12 @@ class InquiryMapperImpl : InquiryMapper {
     override fun createInquiryAnswerWebRequestToDto(webRequest: CreateInquiryAnswerWebRequest): CreateInquiryAnswerRequest =
         CreateInquiryAnswerRequest(
             answer = webRequest.answer
+        )
+
+    override fun queryAllInquiresWebRequestToDto(webRequest: QueryAllInquiresWebRequest): QueryAllInquiresRequest =
+        QueryAllInquiresRequest(
+            answerStatus = webRequest.answerStatus,
+            keyword = webRequest.keyword ?: ""
         )
 
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/InquiryController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/InquiryController.kt
@@ -10,14 +10,13 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import team.msg.domain.inquiry.enums.AnswerStatus
 import team.msg.domain.inquiry.mapper.InquiryMapper
 import team.msg.domain.inquiry.presentation.response.InquiryDetailResponse
 import team.msg.domain.inquiry.presentation.response.InquiryResponses
 import team.msg.domain.inquiry.presentation.web.CreateInquiryAnswerWebRequest
 import team.msg.domain.inquiry.presentation.web.CreateInquiryWebRequest
+import team.msg.domain.inquiry.presentation.request.QueryAllInquiresWebRequest
 import team.msg.domain.inquiry.presentation.web.UpdateInquiryWebRequest
 import team.msg.domain.inquiry.service.InquiryService
 import java.util.UUID
@@ -43,9 +42,9 @@ class InquiryController(
     }
 
     @GetMapping("/all")
-    fun queryAllInquires(@RequestParam answerStatus: AnswerStatus? = null,
-                         @RequestParam keyword: String = ""): ResponseEntity<InquiryResponses> {
-        val response = inquiryService.queryAllInquiries(answerStatus,keyword)
+    fun queryAllInquires(webRequest: QueryAllInquiresWebRequest): ResponseEntity<InquiryResponses> {
+        val request = inquiryMapper.queryAllInquiresWebRequestToDto(webRequest)
+        val response = inquiryService.queryAllInquiries(request)
         return ResponseEntity.ok(response)
     }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/request/QueryAllInquiresWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/request/QueryAllInquiresWebRequest.kt
@@ -1,0 +1,15 @@
+package team.msg.domain.inquiry.presentation.request
+
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import org.springframework.web.bind.annotation.RequestParam
+import team.msg.domain.inquiry.enums.AnswerStatus
+
+data class QueryAllInquiresWebRequest(
+    @RequestParam
+    @Enumerated(EnumType.STRING)
+    val answerStatus: AnswerStatus?,
+
+    @RequestParam
+    val keyword: String?
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/web/QueryAllInquiresRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/web/QueryAllInquiresRequest.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.inquiry.presentation.web
+
+import team.msg.domain.inquiry.enums.AnswerStatus
+
+data class QueryAllInquiresRequest(
+    val answerStatus: AnswerStatus?,
+    val keyword: String
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryService.kt
@@ -1,17 +1,17 @@
 package team.msg.domain.inquiry.service
 
-import team.msg.domain.inquiry.enums.AnswerStatus
 import team.msg.domain.inquiry.presentation.request.CreateInquiryAnswerRequest
 import team.msg.domain.inquiry.presentation.request.CreateInquiryRequest
 import team.msg.domain.inquiry.presentation.request.UpdateInquiryRequest
 import team.msg.domain.inquiry.presentation.response.InquiryDetailResponse
 import team.msg.domain.inquiry.presentation.response.InquiryResponses
+import team.msg.domain.inquiry.presentation.web.QueryAllInquiresRequest
 import java.util.UUID
 
 interface InquiryService {
     fun createInquiry(request: CreateInquiryRequest)
     fun queryMyInquiries(): InquiryResponses
-    fun queryAllInquiries(answerStatus: AnswerStatus?, keyword: String): InquiryResponses
+    fun queryAllInquiries(request: QueryAllInquiresRequest): InquiryResponses
     fun queryInquiryDetail(id: UUID): InquiryDetailResponse
     fun deleteInquiry(id: UUID)
     fun rejectInquiry(id: UUID)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
@@ -16,6 +16,7 @@ import team.msg.domain.inquiry.presentation.request.UpdateInquiryRequest
 import team.msg.domain.inquiry.presentation.response.InquiryDetailResponse
 import team.msg.domain.inquiry.presentation.response.InquiryResponse
 import team.msg.domain.inquiry.presentation.response.InquiryResponses
+import team.msg.domain.inquiry.presentation.web.QueryAllInquiresRequest
 import team.msg.domain.inquiry.repository.InquiryAnswerRepository
 import team.msg.domain.inquiry.repository.InquiryRepository
 import team.msg.domain.user.enums.Authority
@@ -67,9 +68,9 @@ class InquiryServiceImpl(
      * @return 자신이 등록한 문의사항 response
      */
     @Transactional(readOnly = true)
-    override fun queryAllInquiries(answerStatus: AnswerStatus?, keyword: String): InquiryResponses {
+    override fun queryAllInquiries(request: QueryAllInquiresRequest): InquiryResponses {
 
-        val inquiries = inquiryRepository.search(answerStatus,keyword)
+        val inquiries = inquiryRepository.search(request.answerStatus, request.keyword)
 
         return InquiryResponse.listOf(inquiries)
     }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/custom/InquiryRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/custom/InquiryRepositoryImpl.kt
@@ -24,5 +24,5 @@ class InquiryRepositoryImpl(
         if(answerStatus == null) null else inquiry.answerStatus.eq(answerStatus)
 
     private fun keywordLike(keyword: String): BooleanExpression? =
-        if(keyword == "") null else inquiry.question.like("%$keyword%")
+        if(keyword == "") null else inquiry.question.contains(keyword)
 }


### PR DESCRIPTION
## 💡 개요
![image](https://github.com/GSM-MSG/Bitgouel-Server/assets/106813267/62bdd966-97dc-4228-ba73-b9b829236afc)

GET /inquiry/all 조회 시 널포인터 예외가 발생하는 걸 고쳤습니다.

## 📃 작업내용
![image](https://github.com/GSM-MSG/Bitgouel-Server/assets/106813267/78d01aa9-9e0f-405d-a909-c8ad674ac6fc)

로깅을 담당하는 aop가 param에 null을 허용하지 않아 발생하는 문제였습니다.
따라서 param을 dto에 담아 얻어옴으로써 문제를 해결했습니다.

## 🔀 변경사항

문의사항 검색 시 .like()를 사용하는데, 키워드 양 옆에 %를 허용하는 게 .contains()와 다를 게 없어서... 이참에 가독성 따져 바꿔주었습니다.
