### PR TITLE
🔀 :: 뽀짝쌤도 동아리에 속한 학생의 학생활동 조회 허용

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -69,11 +69,11 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.GET, "/school").hasRole(ADMIN)
 
             // activity
-            .mvcMatchers(HttpMethod.POST, "/activity").hasRole(STUDENT)
-            .mvcMatchers(HttpMethod.PATCH, "/activity/{id}").hasRole(STUDENT)
-            .mvcMatchers(HttpMethod.PATCH, "/activity/{id}/approve").hasRole(TEACHER)
-            .mvcMatchers(HttpMethod.DELETE, "/activity/{id}").hasRole(STUDENT)
-            .mvcMatchers(HttpMethod.DELETE, "/activity/{id}/reject").hasRole(TEACHER)
+            .mvcMatchers(HttpMethod.POST, "/activity").hasAnyRole(STUDENT, TEACHER, BBOZZAK)
+            .mvcMatchers(HttpMethod.PATCH, "/activity/{id}").hasAnyRole(STUDENT, TEACHER, BBOZZAK)
+            .mvcMatchers(HttpMethod.PATCH, "/activity/{id}/approve").hasAnyRole(TEACHER, BBOZZAK)
+            .mvcMatchers(HttpMethod.DELETE, "/activity/{id}").hasAnyRole(STUDENT, TEACHER, BBOZZAK)
+            .mvcMatchers(HttpMethod.DELETE, "/activity/{id}/reject").hasAnyRole(TEACHER, BBOZZAK)
             .mvcMatchers(HttpMethod.GET, "/activity").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/activity/my").hasRole(STUDENT)
             .mvcMatchers(HttpMethod.GET, "/activity/{student_id}").hasAnyRole(TEACHER, BBOZZAK)

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -76,8 +76,8 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.DELETE, "/activity/{id}/reject").hasRole(TEACHER)
             .mvcMatchers(HttpMethod.GET, "/activity").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/activity/my").hasRole(STUDENT)
-            .mvcMatchers(HttpMethod.GET, "/activity/{student_id}").hasRole(TEACHER)
-            .mvcMatchers(HttpMethod.GET, "/activity/{id}/detail").hasAnyRole(STUDENT, TEACHER, ADMIN)
+            .mvcMatchers(HttpMethod.GET, "/activity/{student_id}").hasAnyRole(TEACHER, BBOZZAK)
+            .mvcMatchers(HttpMethod.GET, "/activity/{id}/detail").hasAnyRole(STUDENT, TEACHER, ADMIN, BBOZZAK)
 
             // post
             .mvcMatchers(HttpMethod.POST, "/post").hasAnyRole(COMPANY_INSTRUCTOR, BBOZZAK, PROFESSOR, GOVERNMENT, ADMIN)


### PR DESCRIPTION
## 💡 개요
요구사항이 변경됨에 따라, 뽀짝쌤도 동아리에 속한 학생의 학생활동 조회 허용하도록 변경하였습니다
## 📃 작업내용
뽀짝쌤도 소속 동아리 학생의 학생활동 조회 API 접근 가능
## 🎸 기타
학생활동 상세정보 API에도 뽀짝쌤이 접근 가능하도록 허용하였는데 비즈니스 로직의 역할 검증 로직에서는 뽀짝쌤을 허용하지 않아서 다른 이슈를 통해 해결해보려고 합니다
