### PR TITLE
🔀  :: 학생 활동 상세 조회 API 권한 검증 로직 리팩토링

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -9,6 +9,7 @@ import team.msg.common.enums.ApproveStatus
 import team.msg.common.util.UserUtil
 import team.msg.domain.bbozzak.model.Bbozzak
 import team.msg.domain.club.model.Club
+import team.msg.domain.club.repository.ClubRepository
 import team.msg.domain.company.model.CompanyInstructor
 import team.msg.domain.government.model.Government
 import team.msg.domain.professor.model.Professor
@@ -38,7 +39,7 @@ class StudentActivityServiceImpl(
     private val studentRepository: StudentRepository,
     private val teacherRepository: TeacherRepository,
     private val studentActivityRepository: StudentActivityRepository,
-    private val applicationEventPublisher: ApplicationEventPublisher
+    private val applicationEventPublisher: ApplicationEventPublisher,private val clubRepository: ClubRepository
 ) : StudentActivityService {
 
     /**
@@ -245,7 +246,10 @@ class StudentActivityServiceImpl(
                 if(entity != studentActivity.teacher)
                     throw ForbiddenStudentActivityException("해당 학생 활동에 대한 권한이 없습니다. info : [ userId = ${user.id} ]")
             }
-            is Bbozzak, 
+            is Bbozzak -> {
+                if(entity.club != studentActivity.student.club)
+                    throw ForbiddenStudentActivityException("해당 학생 활동에 대한 권한이 없습니다. info : [ userId = ${user.id} ]")
+            }
             is Professor, 
             is CompanyInstructor, 
             is Government ->  throw ForbiddenStudentActivityException("유효하지 않은 권한입니다. info : [ userAuthority = ${user.authority} ]")


### PR DESCRIPTION
## 💡 개요
학생 활동 상세 조회 권한 검증 로직을 리팩토링 했습니다
## 📃 작업내용
학생 활동 상세 조회 권한 검증 로직에서 학생 활동을 작성한 학생의 동아리와 뽀짝쌤의 동아리가 같지 않다면 접근하지 못하도록 하는 검증 로직을 추가하였습니다