### PR TITLE
# 252 유저 강제 탈퇴 기능 구현

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
@@ -46,7 +46,7 @@ class AdminController(
         return ResponseEntity.ok(response)
     }
 
-    @DeleteMapping("{user_id}")
+    @DeleteMapping("/{user_id}")
     fun forceWithdraw(@PathVariable("user_id") userId: UUID): ResponseEntity<Void> {
         adminService.forceWithdraw(userId)
         return ResponseEntity.noContent().build()

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
@@ -34,7 +34,7 @@ class AdminController(
         return ResponseEntity.noContent().build()
     }
 
-    @DeleteMapping("/{user_id}")
+    @DeleteMapping("/{user_id}/reject")
     fun rejectUser(@PathVariable("user_id") userId: UUID): ResponseEntity<Void> {
         adminService.rejectUser(userId)
         return ResponseEntity.noContent().build()
@@ -44,5 +44,11 @@ class AdminController(
     fun queryUserDetails(@PathVariable("user_id") userId: UUID): ResponseEntity<UserDetailsResponse> {
         val response = adminService.queryUserDetails(userId)
         return ResponseEntity.ok(response)
+    }
+
+    @DeleteMapping("{user_id}")
+    fun forceWithdraw(@PathVariable("user_id") userId: UUID): ResponseEntity<Void> {
+        adminService.forceWithdraw(userId)
+        return ResponseEntity.noContent().build()
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminService.kt
@@ -11,4 +11,5 @@ interface AdminService {
     fun approveUser(userId: UUID)
     fun rejectUser(userId: UUID)
     fun queryUserDetails(userId: UUID): UserDetailsResponse
+    fun forceWithdraw(userId: UUID)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -89,6 +89,7 @@ class AdminServiceImpl(
 
     /**
      * 유저를 강제 탈퇴 시키는 비지니스 로직입니다
+     * @param 유저를 삭제하기 위한 userId
      */
     @Transactional(rollbackFor = [Exception::class])
     override fun forceWithdraw(userId: UUID) {

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -87,6 +87,18 @@ class AdminServiceImpl(
         return UserResponse.detailOf(user)
     }
 
+    /**
+     * 유저를 강제 탈퇴 시키는 비지니스 로직입니다
+     */
+    @Transactional(rollbackFor = [Exception::class])
+    override fun forceWithdraw(userId: UUID) {
+        val user = userRepository findById userId
+
+        applicationEventPublisher.publishEvent(WithdrawUserEvent(user))
+
+        userRepository.delete(user)
+    }
+
 
     private infix fun UserRepository.findById(id: UUID): User =
         this.findByIdOrNull(id) ?: throw UserNotFoundException("유저를 찾을 수 없습니다. Info [ userId = $id ]")

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -113,8 +113,9 @@ class SecurityConfig(
             // admin
             .mvcMatchers(HttpMethod.GET, "/admin").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.PATCH, "/admin/{user_id}").hasRole(ADMIN)
-            .mvcMatchers(HttpMethod.DELETE, "/admin/{user_id}").hasRole(ADMIN)
+            .mvcMatchers(HttpMethod.DELETE, "/admin/{user_id}/reject").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/admin/{user_id}").hasRole(ADMIN)
+            .mvcMatchers(HttpMethod.DELETE, "/admin/{user_id}").hasRole(ADMIN)
 
             // inquiry
             .mvcMatchers(HttpMethod.POST, "/inquiry").authenticated()


### PR DESCRIPTION
## 💡 개요
* 유저 강제 탈퇴 기능 구현
## 📃 작업내용
* 기존 회원 가입 거절 url을 변경 해주었습니다.
* /admin/{user_id} url로 유저 강제 탈퇴 기능을 매핑 해주었습니다.
* 어드민만 접근할 수 있도록 설정 해주었습니다.
* WithdrawUserEvent를 발행해 user를 삭제 해주었습니다.
## 🎸 기타
* 함수명이 조금 어색한데 더 좋은 함수명 있으면 제시해주세요!