### PR TITLE
🔀 :: 263 유저 수락 API 다수를 수락 가능하도록 변경

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
@@ -29,7 +29,7 @@ class AdminController(
         return ResponseEntity.ok(response)
     }
 
-    @PatchMapping("/{user_id}")
+    @PatchMapping
     fun approveUsers(@RequestParam userIds: List<UUID>): ResponseEntity<Void> {
         adminService.approveUsers(userIds)
         return ResponseEntity.noContent().build()

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.msg.domain.admin.mapper.AdminMapper
 import team.msg.domain.admin.presentation.data.web.QueryUsersWebRequest
@@ -29,8 +30,8 @@ class AdminController(
     }
 
     @PatchMapping("/{user_id}")
-    fun approveUser(@PathVariable("user_id") userId: UUID): ResponseEntity<Void> {
-        adminService.approveUser(userId)
+    fun approveUsers(@RequestParam userIds: List<UUID>): ResponseEntity<Void> {
+        adminService.approveUsers(userIds)
         return ResponseEntity.noContent().build()
     }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminService.kt
@@ -8,7 +8,7 @@ import java.util.UUID
 
 interface AdminService {
     fun queryUsers(request: QueryUsersRequest, pageable: Pageable): UsersResponse
-    fun approveUser(userId: UUID)
+    fun approveUsers(userIds: List<UUID>)
     fun rejectUser(userId: UUID)
     fun queryUserDetails(userId: UUID): UserDetailsResponse
     fun forceWithdraw(userId: UUID)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -35,7 +35,7 @@ class AdminServiceImpl(
 
     /**
      * 회원가입 대기 중인 유저를 승인하는 비즈니스 로직입니다
-     * @param 승인할 유저를 검색하기 위한 userId
+     * @param 승인할 유저들을 검색하기 위한 userIds
      */
     @Transactional(rollbackFor = [Exception::class])
     override fun approveUsers(userIds: List<UUID>) {

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -38,25 +38,27 @@ class AdminServiceImpl(
      * @param 승인할 유저를 검색하기 위한 userId
      */
     @Transactional(rollbackFor = [Exception::class])
-    override fun approveUser(userId: UUID) {
-        val user = userRepository findById userId
+    override fun approveUsers(userIds: List<UUID>) {
+        val users = userRepository.findByIdIn(userIds)
 
-        if(user.approveStatus == ApproveStatus.APPROVED)
-            throw UserAlreadyApprovedException("이미 승인된 유저입니다. Info : [ userId = ${user.id} ]")
+        users.forEach {
+            if (it.approveStatus == ApproveStatus.APPROVED)
+                throw UserAlreadyApprovedException("이미 승인된 유저입니다. Info : [ userId = ${it.id} ]")
+        }
 
-        val approvedUser = user.run {
+        val approvedUsers = users.map {
             User(
-                id = id,
-                email = email,
-                name = name,
-                phoneNumber = phoneNumber,
-                password = password,
-                authority = authority,
+                id = it.id,
+                email = it.email,
+                name = it.name,
+                phoneNumber = it.phoneNumber,
+                password = it.password,
+                authority = it.authority,
                 approveStatus = ApproveStatus.APPROVED
             )
         }
 
-        userRepository.save(approvedUser)
+        userRepository.saveAll(approvedUsers)
     }
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -112,7 +112,7 @@ class SecurityConfig(
 
             // admin
             .mvcMatchers(HttpMethod.GET, "/admin").hasRole(ADMIN)
-            .mvcMatchers(HttpMethod.PATCH, "/admin/{user_id}").hasRole(ADMIN)
+            .mvcMatchers(HttpMethod.PATCH, "/admin").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.DELETE, "/admin/{user_id}/reject").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/admin/{user_id}").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.DELETE, "/admin/{user_id}").hasRole(ADMIN)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/UserRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/UserRepository.kt
@@ -9,4 +9,5 @@ interface UserRepository : CrudRepository<User, UUID>, CustomUserRepository {
     fun existsByEmail(email: String): Boolean
     fun existsByPhoneNumber(phoneNumber: String): Boolean
     fun findByEmail(email: String): User?
+    fun findByIdIn(ids: List<UUID>): List<User>
 }


### PR DESCRIPTION
## 💡 개요
어드민이 유저를 수락할 때 단일 뿐만이 아닌 일괄적으로 유저를 수락할 수 있도록 변경하였습니다
## 📃 작업내용
유저 회원가입 수락 API를 유저를 여러 명 수락 가능 하도록 변경하였습니다
## 🔀 변경사항
유저 회원가입 수락 API가 받는 파라미터를 queryString으로 변경하였습니다
## 🍴 사용방법
기존에 보내던 요청이 예를 들어 ```bitgouel-domain.co.kr/admin/user_id1``` 형식 이었다면
```bitgouel-domain.co.kr/admin?userId=userId1,userId2,userId3```로 변경해서 요청을 보내야 합니다
