### PR TITLE
🔀 :: 266 유저 리스트 api 리팩토링

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/mapper/AdminMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/mapper/AdminMapperImpl.kt
@@ -12,6 +12,7 @@ class AdminMapperImpl : AdminMapper {
     override fun queryUsersWebRequestToDto(webRequest: QueryUsersWebRequest): QueryUsersRequest =
         QueryUsersRequest(
             keyword = webRequest.keyword,
-            authority = webRequest.authority
+            authority = webRequest.authority,
+            approveStatus = webRequest.approveStatus
         )
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
@@ -23,9 +23,9 @@ class AdminController(
     private val adminMapper: AdminMapper
 ) {
     @GetMapping
-    fun queryUser(webRequest: QueryUsersWebRequest, pageable: Pageable): ResponseEntity<UsersResponse> {
+    fun queryUser(webRequest: QueryUsersWebRequest): ResponseEntity<UsersResponse> {
         val request = adminMapper.queryUsersWebRequestToDto(webRequest)
-        val response = adminService.queryUsers(request, pageable)
+        val response = adminService.queryUsers(request)
         return ResponseEntity.ok(response)
     }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/data/request/QueryUsersRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/data/request/QueryUsersRequest.kt
@@ -1,8 +1,10 @@
 package team.msg.domain.admin.presentation.data.request
 
+import team.msg.common.enums.ApproveStatus
 import team.msg.domain.user.enums.Authority
 
 data class QueryUsersRequest(
     val keyword: String,
-    val authority: Authority
+    val authority: Authority,
+    val approveStatus: ApproveStatus
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/data/web/QueryUsersWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/data/web/QueryUsersWebRequest.kt
@@ -1,6 +1,7 @@
 package team.msg.domain.admin.presentation.data.web
 
 import org.springframework.web.bind.annotation.RequestParam
+import team.msg.common.enums.ApproveStatus
 import team.msg.domain.user.enums.Authority
 
 data class QueryUsersWebRequest(
@@ -8,5 +9,8 @@ data class QueryUsersWebRequest(
     val keyword: String = "",
 
     @RequestParam(required = false)
-    val authority: Authority = Authority.ROLE_USER
+    val authority: Authority = Authority.ROLE_USER,
+
+    @RequestParam
+    val approveStatus: ApproveStatus
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminService.kt
@@ -1,13 +1,12 @@
 package team.msg.domain.admin.service
 
-import org.springframework.data.domain.Pageable
 import team.msg.domain.admin.presentation.data.request.QueryUsersRequest
 import team.msg.domain.user.presentation.data.response.UserDetailsResponse
 import team.msg.domain.user.presentation.data.response.UsersResponse
-import java.util.UUID
+import java.util.*
 
 interface AdminService {
-    fun queryUsers(request: QueryUsersRequest, pageable: Pageable): UsersResponse
+    fun queryUsers(request: QueryUsersRequest): UsersResponse
     fun approveUsers(userIds: List<UUID>)
     fun rejectUser(userId: UUID)
     fun queryUserDetails(userId: UUID): UserDetailsResponse

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -29,7 +29,7 @@ class AdminServiceImpl(
     override fun queryUsers(request: QueryUsersRequest): UsersResponse {
         val users = userRepository.query(request.keyword, request.authority, request.approveStatus)
 
-        return UserResponse.pageOf(users)
+        return UserResponse.listOf(users)
     }
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -27,7 +27,7 @@ class AdminServiceImpl(
      * @return 페이징된 학생 정보를 담은 Dto
      */
     override fun queryUsers(request: QueryUsersRequest): UsersResponse {
-        val users = userRepository.query(request.keyword, request.authority)
+        val users = userRepository.query(request.keyword, request.authority, request.approveStatus)
 
         return UserResponse.pageOf(users)
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -22,9 +22,9 @@ class AdminServiceImpl(
     private val applicationEventPublisher: ApplicationEventPublisher
 ) : AdminService {
     /**
-     * 유저를 전체 조회 및 이름으로 조회하는 비즈니스 로직입니다
-     * @param 유저를 검색하기 위한 keyword 및 페이징을 처리하기 위한 pageable
-     * @return 페이징된 학생 정보를 담은 Dto
+     * 유저를 전체 조회 및 이름, 역할, 승인 상태들로 조회하는 비즈니스 로직입니다
+     * @param 유저를 검색할 조건으로 keyword, authority, approveStatus
+     * @return 학생 정보를 리스트로 담은 Dto
      */
     override fun queryUsers(request: QueryUsersRequest): UsersResponse {
         val users = userRepository.query(request.keyword, request.authority, request.approveStatus)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -1,7 +1,6 @@
 package team.msg.domain.admin.service
 
 import org.springframework.context.ApplicationEventPublisher
-import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -27,8 +26,8 @@ class AdminServiceImpl(
      * @param 유저를 검색하기 위한 keyword 및 페이징을 처리하기 위한 pageable
      * @return 페이징된 학생 정보를 담은 Dto
      */
-    override fun queryUsers(request: QueryUsersRequest, pageable: Pageable): UsersResponse {
-        val users = userRepository.query(request.keyword, request.authority, pageable)
+    override fun queryUsers(request: QueryUsersRequest): UsersResponse {
+        val users = userRepository.query(request.keyword, request.authority)
 
         return UserResponse.pageOf(users)
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/user/presentation/data/response/UserResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/user/presentation/data/response/UserResponse.kt
@@ -12,7 +12,7 @@ data class UserResponse (
     val authority: Authority
 ) {
     companion object {
-        fun pageOf(user: User, organization: String) = UserPageResponse(
+        fun listOf(user: User,organization: String) = UserPageResponse(
             name = user.name,
             email = user.email,
             phoneNumber = user.phoneNumber,
@@ -27,7 +27,7 @@ data class UserResponse (
             approveStatus = user.approveStatus
         )
 
-        fun pageOf(users: Page<User>) = UsersResponse(
+        fun listOf(users: List<User>) = UsersResponse(
             users.map {
                 of(it)
             }
@@ -58,7 +58,7 @@ data class AdminUserResponse(
 )
 
 data class UsersResponse(
-    val users: Page<AdminUserResponse>
+    val users: List<AdminUserResponse>
 )
 
 data class UserDetailsResponse(

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/user/service/UserServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/user/service/UserServiceImpl.kt
@@ -26,7 +26,7 @@ class UserServiceImpl(
         val user = userUtil.queryCurrentUser()
         val organization = userUtil.getAuthorityEntityAndOrganization(user).second
 
-        return UserResponse.pageOf(user, organization)
+        return UserResponse.listOf(user, organization)
     }
 
     /**

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/custom/CustomUserRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/custom/CustomUserRepository.kt
@@ -8,6 +8,6 @@ import team.msg.domain.user.repository.custom.projection.UserNameProjectionData
 import java.util.*
 
 interface CustomUserRepository {
-    fun query(keyword: String, authority: Authority, pageable: Pageable): Page<User>
+    fun query(keyword: String, authority: Authority): Page<User>
     fun queryNameById(id: UUID): UserNameProjectionData?
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/custom/CustomUserRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/custom/CustomUserRepository.kt
@@ -2,12 +2,13 @@ package team.msg.domain.user.repository.custom
 
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import team.msg.common.enums.ApproveStatus
 import team.msg.domain.user.enums.Authority
 import team.msg.domain.user.model.User
 import team.msg.domain.user.repository.custom.projection.UserNameProjectionData
 import java.util.*
 
 interface CustomUserRepository {
-    fun query(keyword: String, authority: Authority): Page<User>
+    fun query(keyword: String, authority: Authority, approveStatus: ApproveStatus): List<User>
     fun queryNameById(id: UUID): UserNameProjectionData?
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/custom/impl/CustomUserRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/custom/impl/CustomUserRepositoryImpl.kt
@@ -3,8 +3,6 @@ package team.msg.domain.user.repository.custom.impl
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
-import org.springframework.data.support.PageableExecutionUtils
 import team.msg.domain.user.enums.Authority
 import team.msg.domain.user.model.QUser.user
 import team.msg.domain.user.model.User
@@ -16,8 +14,7 @@ import java.util.*
 class CustomUserRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ) : CustomUserRepository {
-    override fun query(keyword: String, authority: Authority, pageable: Pageable): Page<User> {
-
+    override fun query(keyword: String, authority: Authority): Page<User> {
         /**
          * User를 authority, name 순으로 정렬 및 페이징하여 조회하는 쿼리입니다
          */
@@ -27,23 +24,8 @@ class CustomUserRepositoryImpl(
                 nameLike(keyword),
                 authorityEq(authority)
             )
-            .offset(pageable.offset)
-            .limit(pageable.pageSize.toLong())
             .orderBy(user.authority.asc(), user.name.asc())
             .fetch()
-
-        /**
-         * 검색 조건에 맞게 조회된 행의 개수를 조회하는 쿼리입니다
-         */
-        val countQuery = queryFactory
-            .select(user.count())
-            .where(
-                nameLike(keyword),
-                authorityEq(authority)
-            )
-            .from(user)
-
-        return PageableExecutionUtils.getPage(users, pageable) { countQuery.fetchOne()!! }
     }
 
     /**

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/custom/impl/CustomUserRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/custom/impl/CustomUserRepositoryImpl.kt
@@ -3,6 +3,7 @@ package team.msg.domain.user.repository.custom.impl
 import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.Page
+import team.msg.common.enums.ApproveStatus
 import team.msg.domain.user.enums.Authority
 import team.msg.domain.user.model.QUser.user
 import team.msg.domain.user.model.User
@@ -14,19 +15,24 @@ import java.util.*
 class CustomUserRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ) : CustomUserRepository {
-    override fun query(keyword: String, authority: Authority): Page<User> {
-        /**
-         * User를 authority, name 순으로 정렬 및 페이징하여 조회하는 쿼리입니다
-         */
-        val users = queryFactory
+
+    /**
+     * User를 조회하는 쿼리입니다
+     * 이름, 역할, 승인 상태등을 파라미터로 받아 조건을 지정합니다
+     *
+     * @param 검색할 유저의 이름에 포함되는 keyword, 유저의 역할을 나타내는 authority, 유저의 승인 여부를 나타내는 approveStatus
+     * @return 검색 조건에 부합하는 user 리스트
+     */
+    override fun query(keyword: String, authority: Authority, approveStatus: ApproveStatus): List<User> =
+        queryFactory
             .selectFrom(user)
             .where(
                 nameLike(keyword),
-                authorityEq(authority)
+                authorityEq(authority),
+                approveStatusEq(approveStatus)
             )
             .orderBy(user.authority.asc(), user.name.asc())
             .fetch()
-    }
 
     /**
      * 요청된 유저 아이디에 따라 조회된 유저의 이름을 반환합니다.
@@ -46,4 +52,7 @@ class CustomUserRepositoryImpl(
 
     private fun authorityEq(authority: Authority): BooleanExpression? =
         if(authority == Authority.ROLE_USER) null else user.authority.eq(authority)
+
+    private fun approveStatusEq(approveStatus: ApproveStatus): BooleanExpression =
+        user.approveStatus.eq(approveStatus)
 }


### PR DESCRIPTION
## 💡 개요
유저 리스트를 반환하는 어드민 api를 리팩토링 하였습니다
## 📃 작업내용
* 페이징 처리 시 사용되는 pageable 파라미터 삭제 (page, size, sort 파라미터 삭제)
* 유저의 회원가입 승인 상태를 나타내는 필드인 approveStatus를 검색 조건에 추가했습니다
## 🔀 변경사항
더이상 페이징처리를 하지 않아도 됩니다