### PR TITLE
269 강의 개설 권한 변경 및 강의 approveStatus 삭제

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/mapper/LectureRequestMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/mapper/LectureRequestMapperImpl.kt
@@ -19,14 +19,14 @@ class LectureRequestMapperImpl : LectureRequestMapper{
         completeDate = webRequest.completeDate,
         lectureType = webRequest.lectureType,
         credit = webRequest.credit,
-        maxRegisteredUser = webRequest.maxRegisteredUser
+        maxRegisteredUser = webRequest.maxRegisteredUser,
+        userId = webRequest.userId
     )
 
     /**
      * Lecture list 검색 web Request 를 애플리케이션 영역에서 사용될 Dto 로 매핑합니다.
      */
     override fun queryLectureWebRequestToDto(webRequest: QueryAllLecturesWebRequest) = QueryAllLectureRequest(
-        lectureType = webRequest.type,
-        approveStatus = webRequest.status
+        lectureType = webRequest.type
     )
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
@@ -6,7 +6,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -56,17 +55,5 @@ class LectureController(
     fun queryLectureDetails(@PathVariable id: UUID): ResponseEntity<LectureDetailsResponse> {
         val response = lectureService.queryLectureDetails(id)
         return ResponseEntity.status(HttpStatus.OK).body(response)
-    }
-
-    @PatchMapping("/{id}/approve")
-    fun approveLecture(@PathVariable id: UUID): ResponseEntity<Void> {
-        lectureService.approveLecture(id)
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
-    }
-
-    @DeleteMapping("/{id}/delete")
-    fun rejectLecture(@PathVariable id: UUID): ResponseEntity<Void> {
-        lectureService.approveLecture(id)
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/CreateLectureRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/CreateLectureRequest.kt
@@ -2,10 +2,12 @@ package team.msg.domain.lecture.presentation.data.request
 
 import team.msg.domain.lecture.enums.LectureType
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class CreateLectureRequest (
     val name: String,
     val content: String,
+    val userId: UUID,
     val startDate: LocalDateTime,
     val endDate: LocalDateTime,
     val completeDate: LocalDateTime,

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/QueryAllLectureRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/QueryAllLectureRequest.kt
@@ -1,9 +1,7 @@
 package team.msg.domain.lecture.presentation.data.request
 
-import team.msg.common.enums.ApproveStatus
 import team.msg.domain.lecture.enums.LectureType
 
 data class QueryAllLectureRequest (
-    val lectureType: LectureType?,
-    val approveStatus: ApproveStatus?
+    val lectureType: LectureType?
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
@@ -1,6 +1,5 @@
 package team.msg.domain.lecture.presentation.data.response
 import org.springframework.data.domain.Page
-import team.msg.common.enums.ApproveStatus
 import team.msg.domain.lecture.enums.LectureStatus
 import team.msg.domain.lecture.enums.LectureType
 import team.msg.domain.lecture.model.Lecture
@@ -16,7 +15,6 @@ data class LectureResponse(
     val completeDate: LocalDateTime,
     val lectureType: LectureType,
     val lectureStatus: LectureStatus,
-    val approveStatus: ApproveStatus,
     val headCount: Int,
     val maxRegisteredUser: Int,
     val lecturer: String
@@ -31,7 +29,6 @@ data class LectureResponse(
             completeDate = lecture.completeDate,
             lectureType = lecture.lectureType,
             lectureStatus = lecture.getLectureStatus(),
-            approveStatus = lecture.approveStatus,
             headCount = headCount,
             maxRegisteredUser = lecture.maxRegisteredUser,
             lecturer = lecture.instructor
@@ -46,7 +43,6 @@ data class LectureResponse(
             completeDate = lecture.completeDate,
             lectureType = lecture.lectureType,
             lectureStatus = lecture.getLectureStatus(),
-            approveStatus = lecture.approveStatus,
             headCount = headCount,
             maxRegisteredUser = lecture.maxRegisteredUser,
             isRegistered = isRegistered,
@@ -69,7 +65,6 @@ data class LectureDetailsResponse(
     val completeDate: LocalDateTime,
     val lectureType: LectureType,
     val lectureStatus: LectureStatus,
-    val approveStatus: ApproveStatus,
     val headCount: Int,
     val maxRegisteredUser: Int,
     val isRegistered: Boolean,

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/CreateLectureWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/CreateLectureWebRequest.kt
@@ -11,6 +11,7 @@ import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
 import team.msg.domain.lecture.enums.LectureType
 import java.time.LocalDateTime
+import java.util.UUID
 
 data class CreateLectureWebRequest(
     @field:NotBlank
@@ -18,6 +19,9 @@ data class CreateLectureWebRequest(
 
     @field:NotBlank
     val content: String,
+
+    @field:NotBlank
+    val userId: UUID,
 
     @field:NotNull
     @FutureOrPresent

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/CreateLectureWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/CreateLectureWebRequest.kt
@@ -5,6 +5,7 @@ import javax.persistence.EnumType
 import javax.persistence.Enumerated
 import javax.validation.constraints.Future
 import javax.validation.constraints.FutureOrPresent
+import javax.validation.constraints.Max
 import javax.validation.constraints.Min
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
@@ -42,6 +43,7 @@ data class CreateLectureWebRequest(
     val credit: Int,
 
     @field:NotNull
-    @field:Min(1)
+    @field:Min(5)
+    @field:Max(10)
     val maxRegisteredUser: Int
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/QueryAllLecturesWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/QueryAllLecturesWebRequest.kt
@@ -3,15 +3,10 @@ package team.msg.domain.lecture.presentation.data.web
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
 import org.springframework.web.bind.annotation.RequestParam
-import team.msg.common.enums.ApproveStatus
 import team.msg.domain.lecture.enums.LectureType
 
 data class QueryAllLecturesWebRequest(
     @RequestParam
     @Enumerated(EnumType.STRING)
-    val type: LectureType?,
-
-    @RequestParam
-    @Enumerated(EnumType.STRING)
-    val status: ApproveStatus?
+    val type: LectureType?
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureService.kt
@@ -13,6 +13,4 @@ interface LectureService {
     fun queryLectureDetails(id: UUID): LectureDetailsResponse
     fun signUpLecture(id: UUID)
     fun cancelSignUpLecture(id: UUID)
-    fun approveLecture(id: UUID)
-    fun rejectLecture(id: UUID)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -79,7 +79,7 @@ class LectureServiceImpl(
     override fun queryAllLectures(pageable: Pageable, queryAllLectureRequest: QueryAllLectureRequest): LecturesResponse {
         val lectureType = queryAllLectureRequest.lectureType
 
-        val lectures = lectureRepository.findAllByApproveStatusAndLectureType(pageable, lectureType)
+        val lectures = lectureRepository.findAllByLectureType(pageable, lectureType)
 
         val response = LecturesResponse(
             lectures.map {

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -8,7 +8,6 @@ import team.msg.common.enums.ApproveStatus
 import team.msg.common.util.UserUtil
 import team.msg.domain.lecture.enums.LectureStatus
 import team.msg.domain.lecture.enums.LectureType
-import team.msg.domain.lecture.exception.AlreadyApprovedLectureException
 import team.msg.domain.lecture.exception.AlreadySignedUpLectureException
 import team.msg.domain.lecture.exception.LectureNotFoundException
 import team.msg.domain.lecture.exception.NotAvailableSignUpDateException
@@ -202,49 +201,6 @@ class LectureServiceImpl(
         )
 
         studentRepository.save(updateCreditStudent)
-    }
-
-    /**
-     * 강의 개설 신청을 수락하는 비지니스 로직입니다.
-     * @param 개설을 수락할 대기 상태의 강의 id
-     */
-    @Transactional(rollbackFor = [Exception::class])
-    override fun approveLecture(id: UUID) {
-        val lecture = lectureRepository findById id
-
-        if(lecture.approveStatus == ApproveStatus.APPROVED)
-            throw AlreadyApprovedLectureException("이미 개설 신청이 승인된 강의입니다. info : [ lectureId = $id ]")
-
-        val approveLecture = Lecture(
-            id = lecture.id,
-            user = lecture.user,
-            name = lecture.name,
-            startDate = lecture.startDate,
-            endDate = lecture.endDate,
-            completeDate = lecture.completeDate,
-            content = lecture.content,
-            lectureType = lecture.lectureType,
-            credit = lecture.credit,
-            instructor = lecture.instructor,
-            maxRegisteredUser = lecture.maxRegisteredUser,
-            approveStatus = ApproveStatus.APPROVED
-        )
-
-        lectureRepository.save(approveLecture)
-    }
-
-    /**
-     * 강의 개설 신청을 거절하는 비지니스 로직입니다.
-     * @param 개설을 거절할 대기 상태의 강의 id
-     */
-    @Transactional(rollbackFor = [Exception::class])
-    override fun rejectLecture(id: UUID) {
-        val lecture = lectureRepository findById id
-
-        if(lecture.approveStatus == ApproveStatus.APPROVED)
-            throw AlreadyApprovedLectureException("이미 개설 신청이 승인된 강의입니다. info : [ lectureId = $id ]")
-
-        lectureRepository.delete(lecture)
     }
 
     private infix fun LectureRepository.findById(id: UUID): Lecture = this.findByIdOrNull(id)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -4,7 +4,6 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import team.msg.common.enums.ApproveStatus
 import team.msg.common.util.UserUtil
 import team.msg.domain.lecture.enums.LectureStatus
 import team.msg.domain.lecture.enums.LectureType
@@ -12,7 +11,6 @@ import team.msg.domain.lecture.exception.AlreadySignedUpLectureException
 import team.msg.domain.lecture.exception.LectureNotFoundException
 import team.msg.domain.lecture.exception.NotAvailableSignUpDateException
 import team.msg.domain.lecture.exception.OverMaxRegisteredUserException
-import team.msg.domain.lecture.exception.UnApprovedLectureException
 import team.msg.domain.lecture.exception.UnSignedUpLectureException
 import team.msg.domain.lecture.model.Lecture
 import team.msg.domain.lecture.model.RegisteredLecture
@@ -128,9 +126,6 @@ class LectureServiceImpl(
 
         val lecture = lectureRepository findById id
 
-        if(lecture.approveStatus == ApproveStatus.PENDING)
-            throw UnApprovedLectureException("아직 승인되지 않은 강의입니다. info : [ lectureId = ${lecture.id} ]")
-
         if(lecture.getLectureStatus() == LectureStatus.CLOSED)
             throw NotAvailableSignUpDateException("수강신청이 가능한 시간이 아닙니다. info : [ lectureId = ${lecture.id}, currentTime = ${LocalDateTime.now()} ]")
 
@@ -176,9 +171,6 @@ class LectureServiceImpl(
         val student = studentRepository findByUser user
 
         val lecture = lectureRepository findById id
-
-        if(lecture.approveStatus == ApproveStatus.PENDING)
-            throw UnApprovedLectureException("아직 승인되지 않은 강의입니다. info : [ lectureId = ${lecture.id} ]")
 
         if(lecture.getLectureStatus() == LectureStatus.CLOSED)
             throw NotAvailableSignUpDateException("수강신청 취소가 가능한 시간이 아닙니다. info : [ lectureId = ${lecture.id}, currentTime = ${LocalDateTime.now()} ]")

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -80,15 +80,9 @@ class LectureServiceImpl(
      */
     @Transactional(readOnly = true)
     override fun queryAllLectures(pageable: Pageable, queryAllLectureRequest: QueryAllLectureRequest): LecturesResponse {
-        val user = userUtil.queryCurrentUser()
-
-        val approveStatus = queryAllLectureRequest.approveStatus
         val lectureType = queryAllLectureRequest.lectureType
 
-        val lectures = when(user.authority) {
-            Authority.ROLE_ADMIN -> lectureRepository.findAllByApproveStatusAndLectureType(pageable, approveStatus, lectureType)
-            else -> lectureRepository.findAllByApproveStatusAndLectureType(pageable, ApproveStatus.APPROVED, lectureType)
-        }
+        val lectures = lectureRepository.findAllByApproveStatusAndLectureType(pageable, lectureType)
 
         val response = LecturesResponse(
             lectures.map {

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -87,7 +87,7 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.DELETE, "/post/{id}").hasAnyRole(COMPANY_INSTRUCTOR, BBOZZAK, PROFESSOR, GOVERNMENT, ADMIN)
 
             // lecture
-            .mvcMatchers(HttpMethod.POST, "/lecture").hasAnyRole(PROFESSOR, COMPANY_INSTRUCTOR, GOVERNMENT)
+            .mvcMatchers(HttpMethod.POST, "/lecture").hasAnyRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/lecture").authenticated()
             .mvcMatchers(HttpMethod.POST, "/lecture/{id}").hasRole(STUDENT)
             .mvcMatchers(HttpMethod.DELETE, "/lecture/{id}").hasRole(STUDENT)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/Lecture.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/Lecture.kt
@@ -8,7 +8,6 @@ import javax.persistence.FetchType
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import team.msg.common.entity.BaseUUIDEntity
-import team.msg.common.enums.ApproveStatus
 import team.msg.domain.lecture.enums.LectureStatus
 import team.msg.domain.lecture.enums.LectureType
 import team.msg.domain.user.model.User
@@ -52,10 +51,6 @@ class Lecture(
 
     @Column(columnDefinition = "TINYINT UNSIGNED", nullable = false)
     val maxRegisteredUser: Int,
-
-    @Enumerated(EnumType.STRING)
-    @Column(columnDefinition = "VARCHAR(10)", nullable = false)
-    var approveStatus: ApproveStatus = ApproveStatus.PENDING
 ) : BaseUUIDEntity(id) {
     fun getLectureStatus(): LectureStatus {
         val currentTime = LocalDateTime.now()

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/CustomLectureRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/CustomLectureRepository.kt
@@ -7,6 +7,6 @@ import team.msg.domain.lecture.model.Lecture
 import java.util.UUID
 
 interface CustomLectureRepository {
-    fun findAllByApproveStatusAndLectureType(pageable: Pageable, lectureType: LectureType?): Page<Lecture>
+    fun findAllByLectureType(pageable: Pageable,lectureType: LectureType?): Page<Lecture>
     fun deleteAllByUserId(userId: UUID)
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/CustomLectureRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/CustomLectureRepository.kt
@@ -2,12 +2,11 @@ package team.msg.domain.lecture.repository.custom
 
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
-import team.msg.common.enums.ApproveStatus
 import team.msg.domain.lecture.enums.LectureType
 import team.msg.domain.lecture.model.Lecture
 import java.util.UUID
 
 interface CustomLectureRepository {
-    fun findAllByApproveStatusAndLectureType(pageable: Pageable, approveStatus: ApproveStatus?, lectureType: LectureType?): Page<Lecture>
+    fun findAllByApproveStatusAndLectureType(pageable: Pageable, lectureType: LectureType?): Page<Lecture>
     fun deleteAllByUserId(userId: UUID)
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomLectureRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomLectureRepositoryImpl.kt
@@ -5,7 +5,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
-import team.msg.common.enums.ApproveStatus
 import team.msg.domain.lecture.enums.LectureType
 import team.msg.domain.lecture.model.QLecture.lecture
 import team.msg.domain.lecture.repository.custom.CustomLectureRepository
@@ -17,14 +16,13 @@ import java.util.Objects.isNull
 class CustomLectureRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ) : CustomLectureRepository {
-    override fun findAllByApproveStatusAndLectureType(pageable: Pageable, approveStatus: ApproveStatus?, lectureType: LectureType?) = PageImpl(
+    override fun findAllByApproveStatusAndLectureType(pageable: Pageable, lectureType: LectureType?) = PageImpl(
         queryFactory
             .selectFrom(lecture)
             .leftJoin(lecture.user, user)
             .fetchJoin()
             .where(
-                eqLectureType(lectureType),
-                eqApproveStatus(approveStatus)
+                eqLectureType(lectureType)
             )
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
@@ -38,7 +36,4 @@ class CustomLectureRepositoryImpl(
 
     private fun eqLectureType(lectureType: LectureType?): BooleanExpression? =
         if(isNull(lectureType)) null else lecture.lectureType.eq(lectureType)
-
-    private fun eqApproveStatus(approveStatus: ApproveStatus?): BooleanExpression? =
-        if(isNull(approveStatus)) null else lecture.approveStatus.eq(approveStatus)
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomLectureRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomLectureRepositoryImpl.kt
@@ -16,7 +16,7 @@ import java.util.Objects.isNull
 class CustomLectureRepositoryImpl(
     private val queryFactory: JPAQueryFactory
 ) : CustomLectureRepository {
-    override fun findAllByApproveStatusAndLectureType(pageable: Pageable, lectureType: LectureType?) = PageImpl(
+    override fun findAllByLectureType(pageable: Pageable,lectureType: LectureType?) = PageImpl(
         queryFactory
             .selectFrom(lecture)
             .leftJoin(lecture.user, user)


### PR DESCRIPTION
## 💡 개요
강의 개설 권한 변경 및 강의 approveStatus를 삭제했습니다.

## 📃 작업내용
- 강의 개설 api request에 userId를 추가했습니다. 
- 강의 리스트 조회 api QueryString에서 approveStatuse를 삭제했습니다.
- 강의 리스트 및 상세 조회 api response에서 approveStatuse를 삭제했습니다.
- 대기 중인 강의 수락 및 거절 api를 삭제했습니다.
- 강의 model에서 approveStatus를 삭제했습니다.

## 🔀 변경사항
- 강의 최소 인원을 5, 최대 인원을 10으로 설정했습니다.
- 강의 개설 권한을 어드민으로 변경했습니다.

## 🎸 기타
강사 추가에 관해서 디자인과 이야기 해본 결과, 유저를 검색해서 하는 방식으로 결정했어요. 추후에 강사 검색 api를 추가하겠습니다!