### PR TITLE
# 272 자격증 조회 권한을 학생 상세 조회와 같게 변경

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
@@ -49,7 +49,7 @@ class CertificationServiceImpl(
     }
 
     /**
-     * 학생이 자격증 리스트를 조회하는 비지니스 로직입니다.
+     * 학생이 자신의 자격증 리스트를 조회하는 비지니스 로직입니다.
      * @return 학생의 자격증 리스트
      */
     @Transactional(readOnly = true)
@@ -68,7 +68,7 @@ class CertificationServiceImpl(
     }
 
     /**
-     * 선생님이 자격증 리스트를 조회하는 비지니스 로직입니다.
+     * 학생의 자격증 리스트를 조회하는 비지니스 로직입니다.
      * @param 자격증 리스트를 조회하기 위한 학생 id
      * @return 학생의 자격증 리스트
      */

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -103,7 +103,7 @@ class SecurityConfig(
             // certification
             .mvcMatchers(HttpMethod.POST, "/certification").hasRole(STUDENT)
             .mvcMatchers(HttpMethod.GET, "/certification").hasRole(STUDENT)
-            .mvcMatchers(HttpMethod.GET, "/certification/{student_id}").hasAnyRole(TEACHER, ADMIN)
+            .mvcMatchers(HttpMethod.GET, "/certification/{student_id}").hasAnyRole(STUDENT, ADMIN, PROFESSOR, COMPANY_INSTRUCTOR, BBOZZAK, TEACHER, GOVERNMENT)
             .mvcMatchers(HttpMethod.PATCH, "/certification/{id}").hasRole(STUDENT)
 
             // user

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -103,7 +103,7 @@ class SecurityConfig(
             // certification
             .mvcMatchers(HttpMethod.POST, "/certification").hasRole(STUDENT)
             .mvcMatchers(HttpMethod.GET, "/certification").hasRole(STUDENT)
-            .mvcMatchers(HttpMethod.GET, "/certification/{student_id}").hasRole(TEACHER)
+            .mvcMatchers(HttpMethod.GET, "/certification/{student_id}").hasAnyRole(TEACHER, ADMIN)
             .mvcMatchers(HttpMethod.PATCH, "/certification/{id}").hasRole(STUDENT)
 
             // user


### PR DESCRIPTION
## 💡 개요
자격증 조회 권한을 학생 상세 조회와 같게 변경
## 📃 작업내용
자격증 조회 서비스의 주석을 더 상세히 적어주었습니다.
자격증 조회 권한을 학생 상세 조회와 같게 변경해 주었습니다.