### PR TITLE
# 275 Script time out 시간 늘리기

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -15,5 +15,5 @@ permissions:
 hooks:
   ApplicationStart:
     - location: scripts/deploy.sh
-      timeout: 60
+      timeout: 180
       runas: ec2-user


### PR DESCRIPTION
## 💡 개요
Script time out 시간 늘리기
## 📃 작업내용
기존에 스크립트 타임아웃 시간이 60초로 설정되어 제대로 배포되지 않는 경우가 있었습니다. 해결하기 위해 180초로 늘려주었습니다.
