### PR TITLE
🔀  :: 탈퇴 예정자 response 변경

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/withdraw/presentation/data/response/WithdrawStudentResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/withdraw/presentation/data/response/WithdrawStudentResponse.kt
@@ -5,13 +5,13 @@ import java.util.UUID
 
 data class WithdrawStudentResponse(
     val withdrawId: Long,
-    val studentId: UUID,
+    val userId: UUID,
     val studentName: String
 ) {
     companion object {
         fun of(withdraw: WithdrawStudent) = WithdrawStudentResponse(
             withdrawId = withdraw.id,
-            studentId = withdraw.student.id,
+            userId = withdraw.student.user!!.id,
             studentName = withdraw.student.user!!.name
         )
 


### PR DESCRIPTION
## 💡 개요
탈퇴 예정자 리스트를 반환할 때 studentId 대신 userId를 반환하도록 변경했습니다
## 📃 작업내용
WithdrawStudentResponse에 studentId 대신 userId를 담아 반환하도록 of 함수 변경