### PR TITLE
🔀 :: 289 어드민 도메인 테스트 코드 작성

### DIFF
--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -184,4 +184,13 @@ class AdminServiceImplTest : BehaviorSpec({
             }
         }
     }
+
+    // forceWithdraw 테스트 코드
+    Given("userId가 주어지면") {
+        val userId = UUID.randomUUID()
+
+        val user = fixture<User> {
+            property(User::id) { userId }
+        }
+    }
 })

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -9,6 +9,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.data.repository.findByIdOrNull
 import team.msg.common.enums.ApproveStatus
 import team.msg.domain.admin.presentation.data.request.QueryUsersRequest
 import team.msg.domain.user.enums.Authority
@@ -105,6 +106,20 @@ class AdminServiceImplTest : BehaviorSpec({
                     adminServiceImpl.approveUsers(listOf(userId))
                 }
             }
+        }
+    }
+
+    // rejectUser 테스트 코드
+    Given("userId 가 주어졌을 때") {
+        val userId = UUID.randomUUID()
+
+        val user = fixture<User> {
+            property(User::id) { userId }
+            property(User::approveStatus) { ApproveStatus.PENDING }
+        }
+
+        val approvedUser = fixture<User> {
+            property(User::approveStatus) { ApproveStatus.APPROVED }
         }
     }
 })

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -1,0 +1,20 @@
+package team.msg.domain.admin.service
+
+import com.appmattus.kotlinfixture.kotlinFixture
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.mockk
+import org.springframework.context.ApplicationEventPublisher
+import team.msg.domain.user.repository.UserRepository
+
+class AdminServiceImplTest : BehaviorSpec({
+    isolationMode = IsolationMode.InstancePerLeaf
+    val fixture = kotlinFixture()
+
+    val userRepository = mockk<UserRepository>()
+    val applicationEventPublisher = mockk<ApplicationEventPublisher>()
+    val adminServiceImpl = AdminServiceImpl(
+        userRepository = userRepository,
+        applicationEventPublisher = applicationEventPublisher
+    )
+})

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -60,5 +60,13 @@ class AdminServiceImplTest : BehaviorSpec({
         }
 
         every { userRepository.query(keyword, authority, approveStatus) } returns listOf(user)
+
+        When("User 리스트 요청 시") {
+            val result = adminServiceImpl.queryUsers(request)
+
+            Then("result가 response와 같아야 한다") {
+                result shouldBe response
+            }
+        }
     }
 })

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -196,5 +196,17 @@ class AdminServiceImplTest : BehaviorSpec({
         every { userRepository.findByIdOrNull(userId) } returns user
         every { applicationEventPublisher.publishEvent(WithdrawUserEvent(user)) } just Runs
         every { userRepository.delete(user) } returns Unit
+
+        When("User 강제 탈퇴 시") {
+            adminServiceImpl.forceWithdraw(userId)
+
+            Then("withdrawUserEvent 를 발행해야 한다") {
+                verify(exactly = 1) { applicationEventPublisher.publishEvent(WithdrawUserEvent(user)) }
+            }
+
+            Then("User가 삭제가 되어야 한다") {
+                verify(exactly = 1) { userRepository.delete(user) }
+            }
+        }
     }
 })

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -128,5 +128,27 @@ class AdminServiceImplTest : BehaviorSpec({
         every { userRepository.findByIdOrNull(userId) } returns user
         every { applicationEventPublisher.publishEvent(WithdrawUserEvent(user)) } just Runs
         every { userRepository.delete(any()) } returns Unit
+
+        When("User 회원가입 거절 시") {
+            adminServiceImpl.rejectUser(userId)
+
+            Then("withdrawUserEvent 를 발행해야 한다") {
+                verify(exactly = 1) { applicationEventPublisher.publishEvent(WithdrawUserEvent(user)) }
+            }
+
+            Then("User가 삭제가 되어야 한다") {
+                verify(exactly = 1) { userRepository.delete(user) }
+            }
+        }
+
+        When("이미 승인된 User 라면") {
+            every { userRepository.findByIdOrNull(userId) } returns approvedUser
+
+            Then("UserAlreadyApprovedException 이 발생해야 한다") {
+                shouldThrow<UserAlreadyApprovedException> {
+                    adminServiceImpl.rejectUser(userId)
+                }
+            }
+        }
     }
 })

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -19,6 +19,7 @@ import team.msg.domain.user.event.WithdrawUserEvent
 import team.msg.domain.user.exception.UserAlreadyApprovedException
 import team.msg.domain.user.model.User
 import team.msg.domain.user.presentation.data.response.AdminUserResponse
+import team.msg.domain.user.presentation.data.response.UserDetailsResponse
 import team.msg.domain.user.presentation.data.response.UsersResponse
 import team.msg.domain.user.repository.UserRepository
 import java.util.*
@@ -149,6 +150,28 @@ class AdminServiceImplTest : BehaviorSpec({
                     adminServiceImpl.rejectUser(userId)
                 }
             }
+        }
+    }
+
+    // queryUserDetails 테스트 코드
+    Given("userId가 주어졌을 때") {
+        val userId = UUID.randomUUID()
+        val name = "name"
+        val authority = Authority.ROLE_STUDENT
+        val approveStatus = ApproveStatus.APPROVED
+
+        val user = fixture<User> {
+            property(User::id) { userId }
+            property(User::name) { name }
+            property(User::authority) { authority }
+            property(User::approveStatus) { approveStatus }
+        }
+
+        val response = fixture<UserDetailsResponse> {
+            property(UserDetailsResponse::id) { userId }
+            property(UserDetailsResponse::name) { name }
+            property(UserDetailsResponse::authority) { authority }
+            property(UserDetailsResponse::approveStatus) { approveStatus }
         }
     }
 })

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -192,5 +192,9 @@ class AdminServiceImplTest : BehaviorSpec({
         val user = fixture<User> {
             property(User::id) { userId }
         }
+
+        every { userRepository.findByIdOrNull(userId) } returns user
+        every { applicationEventPublisher.publishEvent(WithdrawUserEvent(user)) } just Runs
+        every { userRepository.delete(user) } returns Unit
     }
 })

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -3,9 +3,18 @@ package team.msg.domain.admin.service
 import com.appmattus.kotlinfixture.kotlinFixture
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
 import io.mockk.mockk
 import org.springframework.context.ApplicationEventPublisher
+import team.msg.common.enums.ApproveStatus
+import team.msg.domain.admin.presentation.data.request.QueryUsersRequest
+import team.msg.domain.user.enums.Authority
+import team.msg.domain.user.model.User
+import team.msg.domain.user.presentation.data.response.AdminUserResponse
+import team.msg.domain.user.presentation.data.response.UsersResponse
 import team.msg.domain.user.repository.UserRepository
+import java.util.*
 
 class AdminServiceImplTest : BehaviorSpec({
     isolationMode = IsolationMode.InstancePerLeaf
@@ -17,4 +26,33 @@ class AdminServiceImplTest : BehaviorSpec({
         userRepository = userRepository,
         applicationEventPublisher = applicationEventPublisher
     )
+
+    // queryUsers 테스트 코드
+    Given("QueryUsersRequest가 주어졌을 때") {
+        val userId = UUID.randomUUID()
+        val keyword = "keyword"
+        val authority = Authority.ROLE_STUDENT
+        val approveStatus = ApproveStatus.APPROVED
+
+        val user = fixture<User> {
+            property(User::id) { userId }
+            property(User::name) { keyword }
+            property(User::authority) { authority }
+            property(User::approveStatus) { approveStatus }
+
+        }
+
+        val request = fixture<QueryUsersRequest> {
+            property(QueryUsersRequest::keyword) { keyword }
+            property(QueryUsersRequest::authority) { authority }
+            property(QueryUsersRequest::approveStatus) { approveStatus }
+        }
+
+        val adminUserResponse = fixture<AdminUserResponse> {
+            property(AdminUserResponse::id) { userId }
+            property(AdminUserResponse::name) { keyword }
+            property(AdminUserResponse::authority) { authority }
+            property(AdminUserResponse::approveStatus) { approveStatus }
+        }
+    }
 })

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -69,4 +69,18 @@ class AdminServiceImplTest : BehaviorSpec({
             }
         }
     }
+
+    // approveUsers 테스트 코드
+    Given("userIds가 주어졌을때") {
+        val userIds = UUID.randomUUID()
+
+        val user = fixture<User> {
+            property(User::id) { userIds }
+            property(User::approveStatus) { ApproveStatus.PENDING }
+        }
+
+        val approvedUser = fixture<User> {
+            property(User::approveStatus) { ApproveStatus.APPROVED }
+        }
+    }
 })

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -175,5 +175,13 @@ class AdminServiceImplTest : BehaviorSpec({
         }
 
         every { userRepository.findByIdOrNull(userId) } returns user
+
+        When("User 상세 정보 요청 시") {
+            val result = adminServiceImpl.queryUserDetails(userId)
+
+            Then("result가 response와 같아야 한다") {
+                result shouldBe response
+            }
+        }
     }
 })

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -5,7 +5,9 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import org.springframework.context.ApplicationEventPublisher
@@ -13,6 +15,7 @@ import org.springframework.data.repository.findByIdOrNull
 import team.msg.common.enums.ApproveStatus
 import team.msg.domain.admin.presentation.data.request.QueryUsersRequest
 import team.msg.domain.user.enums.Authority
+import team.msg.domain.user.event.WithdrawUserEvent
 import team.msg.domain.user.exception.UserAlreadyApprovedException
 import team.msg.domain.user.model.User
 import team.msg.domain.user.presentation.data.response.AdminUserResponse
@@ -121,5 +124,9 @@ class AdminServiceImplTest : BehaviorSpec({
         val approvedUser = fixture<User> {
             property(User::approveStatus) { ApproveStatus.APPROVED }
         }
+
+        every { userRepository.findByIdOrNull(userId) } returns user
+        every { applicationEventPublisher.publishEvent(WithdrawUserEvent(user)) } just Runs
+        every { userRepository.delete(any()) } returns Unit
     }
 })

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -1,6 +1,7 @@
 package team.msg.domain.admin.service
 
 import com.appmattus.kotlinfixture.kotlinFixture
+import io.kotest.assertions.any
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -82,5 +83,8 @@ class AdminServiceImplTest : BehaviorSpec({
         val approvedUser = fixture<User> {
             property(User::approveStatus) { ApproveStatus.APPROVED }
         }
+
+        every { userRepository.findByIdIn(listOf(userIds)) } returns listOf(user)
+        every { userRepository.saveAll(listOf(user)) } returns listOf(user)
     }
 })

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -173,5 +173,7 @@ class AdminServiceImplTest : BehaviorSpec({
             property(UserDetailsResponse::authority) { authority }
             property(UserDetailsResponse::approveStatus) { approveStatus }
         }
+
+        every { userRepository.findByIdOrNull(userId) } returns user
     }
 })

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -54,5 +54,11 @@ class AdminServiceImplTest : BehaviorSpec({
             property(AdminUserResponse::authority) { authority }
             property(AdminUserResponse::approveStatus) { approveStatus }
         }
+
+        val response = fixture<UsersResponse> {
+            property(UsersResponse::users) { listOf(adminUserResponse) }
+        }
+
+        every { userRepository.query(keyword, authority, approveStatus) } returns listOf(user)
     }
 })


### PR DESCRIPTION
## 💡 개요
어드민 도메인의 서비스 로직 테스트 코드를 작성하였습니다
## 📃 작업내용
* queryUsers 테스트 코드 작성
* approveUsers 테스트 코드 작성
* rejectUser 테스트 코드 작성
* queryUserDetails 테스트 코드 작성
* forceWithdraw 테스트 코드 작성