### PR TITLE
🔀  :: student entity 삭제 시 withdraw student entity 함께 삭제

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/user/handler/UserEventHandler.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/user/handler/UserEventHandler.kt
@@ -33,6 +33,7 @@ import team.msg.domain.teacher.repository.TeacherRepository
 import team.msg.domain.user.enums.Authority.*
 import team.msg.domain.user.event.WithdrawUserEvent
 import team.msg.domain.user.model.User
+import team.msg.domain.withdraw.repository.WithdrawStudentRepository
 
 @Component
 class UserEventHandler(
@@ -47,7 +48,8 @@ class UserEventHandler(
     private val adminRepository: AdminRepository,
     private val lectureRepository: LectureRepository,
     private val certificationRepository: CertificationRepository,
-    private val postRepository: PostRepository
+    private val postRepository: PostRepository,
+    private val withdrawStudentRepository: WithdrawStudentRepository
 ) {
 
     /**
@@ -65,6 +67,7 @@ class UserEventHandler(
                 studentActivityRepository.deleteAllByStudentId(student.id)
                 registeredLectureRepository.deleteAllByStudentId(student.id)
                 certificationRepository.deleteAllByStudentId(student.id)
+                withdrawStudentRepository.deleteByStudent(student)
                 studentRepository.delete(student)
             }
             ROLE_ADMIN -> {

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/withdraw/repository/WithdrawStudentRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/withdraw/repository/WithdrawStudentRepository.kt
@@ -3,7 +3,9 @@ package team.msg.domain.withdraw.repository
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.student.model.Student
 import team.msg.domain.withdraw.model.WithdrawStudent
+import java.util.UUID
 
 interface WithdrawStudentRepository : CrudRepository<WithdrawStudent, Long> {
     fun findByStudentIn(students: List<Student>): List<WithdrawStudent>
+    fun deleteByStudent(student: Student)
 }


### PR DESCRIPTION
## 💡 개요
student entity 삭제 시 withdraw student entity 함께 삭제
## 📃 작업내용
* withdraw student repository에 deleteByStudent 쿼리 메서드 정의
* withdrawUserHandler에서 student일 때 withdraw student 엔티티 삭제 로직 추가
