### PR TITLE
게시글 url 검토 방식 변경

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/mapper/PostRequestMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/mapper/PostRequestMapperImpl.kt
@@ -15,7 +15,7 @@ class PostRequestMapperImpl : PostRequestMapper {
         CreatePostRequest(
             title = title,
             content = content,
-            links = links.map { it.url },
+            links = links,
             feedType = feedType
         )
     }
@@ -27,7 +27,7 @@ class PostRequestMapperImpl : PostRequestMapper {
         UpdatePostRequest(
             title = title,
             content = content,
-            links = links.map { it.url }
+            links = links
         )
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/web/CreatePostWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/web/CreatePostWebRequest.kt
@@ -4,8 +4,8 @@ import javax.validation.Valid
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
 import javax.validation.constraints.Size
-import org.hibernate.validator.constraints.URL
 import team.msg.domain.post.enums.FeedType
+import team.msg.domain.post.presentation.web.validation.URLList
 
 data class CreatePostWebRequest(
     @field:NotBlank
@@ -17,15 +17,9 @@ data class CreatePostWebRequest(
     val content: String,
 
     @field:Valid
-    val links: List<LinkWebRequest>,
+    @field:URLList
+    val links: List<String>,
 
     @field:NotNull
     val feedType: FeedType
-){
-    data class LinkWebRequest(
-        @field:URL
-        @field:NotBlank
-        @field:Size(max=2083)
-        val url: String
-    )
-}
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/web/UpdatePostWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/web/UpdatePostWebRequest.kt
@@ -3,7 +3,7 @@ package team.msg.domain.post.presentation.web
 import javax.validation.Valid
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.Size
-import org.hibernate.validator.constraints.URL
+import team.msg.domain.post.presentation.web.validation.URLList
 
 data class UpdatePostWebRequest(
     @field:NotBlank
@@ -15,12 +15,6 @@ data class UpdatePostWebRequest(
     val content: String,
 
     @field:Valid
-    val links: List<LinkWebRequest>
-){
-    data class LinkWebRequest(
-        @field:URL
-        @field:NotBlank
-        @field:Size(max=2083)
-        val url: String
-    )
-}
+    @field:URLList
+    val links: List<String>
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/web/validation/URLList.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/web/validation/URLList.kt
@@ -1,0 +1,13 @@
+package team.msg.domain.post.presentation.web.validation
+
+import javax.validation.Constraint
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [URLListValidator::class])
+annotation class URLList (
+    val message: String = "올바른 URL 형식이 아닙니다.",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<*>> = [],
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/web/validation/URLListValidator.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/web/validation/URLListValidator.kt
@@ -1,0 +1,16 @@
+package team.msg.domain.post.presentation.web.validation
+
+import javax.validation.ConstraintValidator
+import javax.validation.ConstraintValidatorContext
+
+class URLListValidator : ConstraintValidator<URLList, List<String>> {
+    override fun isValid(values: List<String>?, context: ConstraintValidatorContext?): Boolean {
+        val urls = values ?: return false
+
+        val regex = Regex("\\b(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]")
+
+        return urls.none { regex.notMatches(it) || it.length > 2083 }
+    }
+}
+
+fun Regex.notMatches(input: String) = !this.matches(input)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/web/validation/URLListValidator.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/web/validation/URLListValidator.kt
@@ -7,7 +7,7 @@ class URLListValidator : ConstraintValidator<URLList, List<String>> {
     override fun isValid(values: List<String>?, context: ConstraintValidatorContext?): Boolean {
         val urls = values ?: return false
 
-        val regex = Regex("\\b(https?|ftp|file)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]")
+        val regex = Regex("\\b(https?)://[-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|]")
 
         return urls.none { regex.notMatches(it) || it.length > 2083 }
     }


### PR DESCRIPTION
## 💡 개요
게시글 생성, 변경 시 url 검토 방식을 변경했습니다.

## 📃 작업내용
게시글 url을 String list로 받도록하고, custom validator를 추가해 url 형식을 검증하도록 했습니다.

## 🔀 변경사항
게시글 생성, 변경 api의 url 입력을 String list로 변경했습니다.

## 🍴 사용방법
url로 구성된 List<String>을 검증하고 싶을 때 구성요소 위에 @field:URLList를 붙여주면 됩니다!