### PR TITLE
🔀 :: 297 유저 거절 api 다수 거절 가능하도록 변경

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
@@ -35,7 +35,7 @@ class AdminController(
     }
 
     @DeleteMapping("/reject")
-    fun rejectUser(@RequestParam userIds: List<UUID>): ResponseEntity<Void> {
+    fun rejectUsers(@RequestParam userIds: List<UUID>): ResponseEntity<Void> {
         adminService.rejectUsers(userIds)
         return ResponseEntity.noContent().build()
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
@@ -35,9 +35,9 @@ class AdminController(
         return ResponseEntity.noContent().build()
     }
 
-    @DeleteMapping("/{user_id}/reject")
-    fun rejectUser(@PathVariable("user_id") userId: UUID): ResponseEntity<Void> {
-        adminService.rejectUser(userId)
+    @DeleteMapping("/reject")
+    fun rejectUser(@RequestParam userIds: List<UUID>): ResponseEntity<Void> {
+        adminService.rejectUser(userIds)
         return ResponseEntity.noContent().build()
     }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
@@ -1,6 +1,5 @@
 package team.msg.domain.admin.presentation
 
-import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -37,7 +36,7 @@ class AdminController(
 
     @DeleteMapping("/reject")
     fun rejectUser(@RequestParam userIds: List<UUID>): ResponseEntity<Void> {
-        adminService.rejectUser(userIds)
+        adminService.rejectUsers(userIds)
         return ResponseEntity.noContent().build()
     }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminService.kt
@@ -8,7 +8,7 @@ import java.util.*
 interface AdminService {
     fun queryUsers(request: QueryUsersRequest): UsersResponse
     fun approveUsers(userIds: List<UUID>)
-    fun rejectUser(userIds: List<UUID>)
+    fun rejectUsers(userIds: List<UUID>)
     fun queryUserDetails(userId: UUID): UserDetailsResponse
     fun forceWithdraw(userId: UUID)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminService.kt
@@ -8,7 +8,7 @@ import java.util.*
 interface AdminService {
     fun queryUsers(request: QueryUsersRequest): UsersResponse
     fun approveUsers(userIds: List<UUID>)
-    fun rejectUser(userId: UUID)
+    fun rejectUser(userIds: List<UUID>)
     fun queryUserDetails(userId: UUID): UserDetailsResponse
     fun forceWithdraw(userId: UUID)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -65,15 +65,17 @@ class AdminServiceImpl(
      * @param 거절할 유저를 검색하기 위한 userId
      */
     @Transactional(rollbackFor = [Exception::class])
-    override fun rejectUser(userId: UUID) {
-        val user = userRepository findById userId
+    override fun rejectUser(userIds: List<UUID>) {
+        val users = userRepository.findByIdIn(userIds)
 
-        if(user.approveStatus == ApproveStatus.APPROVED)
-            throw UserAlreadyApprovedException("이미 승인된 유저입니다. Info : [ userId = ${user.id} ]")
+        users.forEach {
+            if(it.approveStatus == ApproveStatus.APPROVED)
+                throw UserAlreadyApprovedException("이미 승인된 유저입니다. Info : [ userId = ${it.id} ]")
 
-        applicationEventPublisher.publishEvent(WithdrawUserEvent(user))
+        applicationEventPublisher.publishEvent(WithdrawUserEvent(it))
 
-        userRepository.delete(user)
+        userRepository.delete(it)
+        }
     }
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -65,17 +65,18 @@ class AdminServiceImpl(
      * @param 거절할 유저를 검색하기 위한 userId
      */
     @Transactional(rollbackFor = [Exception::class])
-    override fun rejectUser(userIds: List<UUID>) {
+    override fun rejectUsers(userIds: List<UUID>) {
         val users = userRepository.findByIdIn(userIds)
 
         users.forEach {
+
             if(it.approveStatus == ApproveStatus.APPROVED)
                 throw UserAlreadyApprovedException("이미 승인된 유저입니다. Info : [ userId = ${it.id} ]")
 
-        applicationEventPublisher.publishEvent(WithdrawUserEvent(it))
-
-        userRepository.delete(it)
+            applicationEventPublisher.publishEvent(WithdrawUserEvent(it))
         }
+
+        userRepository.deleteByIdIn(userIds)
     }
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -62,7 +62,7 @@ class AdminServiceImpl(
 
     /**
      * 회원가입 대기 중인 유저를 거절하는 비즈니스 로직입니다
-     * @param 거절할 유저를 검색하기 위한 userId
+     * @param 거절할 유저들을 검색하기 위한 userIds
      */
     @Transactional(rollbackFor = [Exception::class])
     override fun rejectUsers(userIds: List<UUID>) {

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -110,7 +110,7 @@ class SecurityConfig(
             // admin
             .mvcMatchers(HttpMethod.GET, "/admin").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.PATCH, "/admin").hasRole(ADMIN)
-            .mvcMatchers(HttpMethod.DELETE, "/admin/{user_id}/reject").hasRole(ADMIN)
+            .mvcMatchers(HttpMethod.DELETE, "/admin/reject").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/admin/{user_id}").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.DELETE, "/admin/{user_id}").hasRole(ADMIN)
 

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -113,8 +113,8 @@ class AdminServiceImplTest : BehaviorSpec({
         }
     }
 
-    // rejectUser 테스트 코드
-    Given("userId 가 주어졌을 때") {
+    // rejectUsers 테스트 코드
+    Given("userIds 가 주어졌을 때") {
         val userId = UUID.randomUUID()
         val userIds = listOf(userId)
 

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/admin/service/AdminServiceImplTest.kt
@@ -131,7 +131,7 @@ class AdminServiceImplTest : BehaviorSpec({
         every { userRepository.delete(any()) } returns Unit
 
         When("User 회원가입 거절 시") {
-            adminServiceImpl.rejectUser(userId)
+            adminServiceImpl.rejectUsers(userId)
 
             Then("withdrawUserEvent 를 발행해야 한다") {
                 verify(exactly = 1) { applicationEventPublisher.publishEvent(WithdrawUserEvent(user)) }
@@ -147,7 +147,7 @@ class AdminServiceImplTest : BehaviorSpec({
 
             Then("UserAlreadyApprovedException 이 발생해야 한다") {
                 shouldThrow<UserAlreadyApprovedException> {
-                    adminServiceImpl.rejectUser(userId)
+                    adminServiceImpl.rejectUsers(userId)
                 }
             }
         }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/UserRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/UserRepository.kt
@@ -1,5 +1,6 @@
 package team.msg.domain.user.repository
 
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.user.model.User
 import team.msg.domain.user.repository.custom.CustomUserRepository
@@ -10,4 +11,6 @@ interface UserRepository : CrudRepository<User, UUID>, CustomUserRepository {
     fun existsByPhoneNumber(phoneNumber: String): Boolean
     fun findByEmail(email: String): User?
     fun findByIdIn(ids: List<UUID>): List<User>
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    fun deleteByIdIn(ids: List<UUID>)
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/UserRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/repository/UserRepository.kt
@@ -1,6 +1,7 @@
 package team.msg.domain.user.repository
 
 import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.user.model.User
 import team.msg.domain.user.repository.custom.CustomUserRepository
@@ -12,5 +13,6 @@ interface UserRepository : CrudRepository<User, UUID>, CustomUserRepository {
     fun findByEmail(email: String): User?
     fun findByIdIn(ids: List<UUID>): List<User>
     @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("delete from User u where u.id in :ids")
     fun deleteByIdIn(ids: List<UUID>)
 }


### PR DESCRIPTION
## 💡 개요
유저를 거절할때 다수를 거절 가능하도록 변경하였습니다
## 📃 작업내용
유저 거절 api uri pattern /admin/{userId}/reject 와 PathVariable -> /admin/reject 와 queryString으로 변경
delete batch 쿼리를 위한 deleteByIdIn 쿼리 메소드에 @Modifying 어노테이션 사용