### PR TITLE
🔀 :: 303 학생활동 학생 단위로 조회 API 권한 범위 변경

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -25,7 +25,9 @@ import team.msg.domain.student.repository.StudentRepository
 import team.msg.domain.teacher.exception.TeacherNotFoundException
 import team.msg.domain.teacher.model.Teacher
 import team.msg.domain.teacher.repository.TeacherRepository
+import team.msg.domain.user.enums.Authority
 import team.msg.domain.user.model.User
+import team.msg.global.exception.ForbiddenException
 import java.util.*
 
 @Service
@@ -135,10 +137,16 @@ class StudentActivityServiceImpl(
 
         val student = studentRepository findById studentId
 
-        val teacher = teacherRepository findByUser user
+        when(user.authority) {
+            Authority.ROLE_ADMIN -> {}
+            Authority.ROLE_TEACHER -> {
+                val teacher = teacherRepository findByUser user
 
-        if(student.club != teacher.club)
-            throw ForbiddenStudentActivityException("해당 학생 활동에 대한 권한이 없습니다. info : [ teacherId = ${teacher.id} ]")
+                if(student.club != teacher.club)
+                    throw ForbiddenStudentActivityException("해당 학생 활동에 대한 권한이 없습니다. info : [ teacherId = ${teacher.id} ]")
+            }
+            else -> throw ForbiddenException("Forbidden")
+        }
 
         val studentActivities = studentActivityRepository.findAllByStudent(student, pageable)
 

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -74,7 +74,7 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.DELETE, "/activity/{id}").hasAnyRole(STUDENT, TEACHER, BBOZZAK)
             .mvcMatchers(HttpMethod.GET, "/activity").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/activity/my").hasRole(STUDENT)
-            .mvcMatchers(HttpMethod.GET, "/activity/{student_id}").hasAnyRole(TEACHER, BBOZZAK, ADMIN)
+            .mvcMatchers(HttpMethod.GET, "/activity/{student_id}").hasAnyRole(TEACHER, ADMIN)
             .mvcMatchers(HttpMethod.GET, "/activity/{id}/detail").hasAnyRole(STUDENT, TEACHER, ADMIN, BBOZZAK)
 
             // post

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -74,7 +74,7 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.DELETE, "/activity/{id}").hasAnyRole(STUDENT, TEACHER, BBOZZAK)
             .mvcMatchers(HttpMethod.GET, "/activity").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/activity/my").hasRole(STUDENT)
-            .mvcMatchers(HttpMethod.GET, "/activity/{student_id}").hasAnyRole(TEACHER, BBOZZAK)
+            .mvcMatchers(HttpMethod.GET, "/activity/{student_id}").hasAnyRole(TEACHER, BBOZZAK, ADMIN)
             .mvcMatchers(HttpMethod.GET, "/activity/{id}/detail").hasAnyRole(STUDENT, TEACHER, ADMIN, BBOZZAK)
 
             // post


### PR DESCRIPTION
## 💡 개요
학생 활동 학생 단위 조회 API를 Admin도 접근 가능하도록 변경하였습니다
## 📃 작업내용
* 어드민도 접근 가능함에 따라 비즈니스 로직 리팩토링
* 추가된 분기문에 적합하도록 테스트 코드 수정
