### PR TITLE
강의 수강 날짜 단일 -> 리스트 적용

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/mapper/LectureRequestMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/mapper/LectureRequestMapperImpl.kt
@@ -2,10 +2,12 @@ package team.msg.domain.lecture.mapper
 
 import org.springframework.stereotype.Component
 import team.msg.domain.lecture.presentation.data.request.CreateLectureRequest
+import team.msg.domain.lecture.presentation.data.request.LectureDateRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllDepartmentsRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLinesRequest
 import team.msg.domain.lecture.presentation.data.web.CreateLectureWebRequest
+import team.msg.domain.lecture.presentation.data.web.LectureDateWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllDepartmentsWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllLecturesWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllLinesWebRequest
@@ -24,11 +26,20 @@ class LectureRequestMapperImpl : LectureRequestMapper{
         line = webRequest.line,
         startDate = webRequest.startDate,
         endDate = webRequest.endDate,
-        completeDate = webRequest.completeDate,
+        lectureDates = webRequest.lectureDates.map { lectureDateWebRequestToDto(it) },
         lectureType = webRequest.lectureType,
         credit = webRequest.credit,
         maxRegisteredUser = webRequest.maxRegisteredUser,
         userId = webRequest.userId
+    )
+
+    /**
+     * Lecture Date web Request 를 애플리케이션 영역에서 사용될 Dto 로 매핑합니다.
+     */
+    private fun lectureDateWebRequestToDto(webRequest: LectureDateWebRequest) = LectureDateRequest(
+        completeDate = webRequest.completeDate,
+        startTime = webRequest.startTime,
+        endTime = webRequest.endTime
     )
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/CreateLectureRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/CreateLectureRequest.kt
@@ -16,7 +16,7 @@ data class CreateLectureRequest (
     val userId: UUID,
     val startDate: LocalDateTime,
     val endDate: LocalDateTime,
-    val completeDate: LocalDateTime,
+    val lectureDates: List<LectureDateRequest>,
     val lectureType: LectureType,
     val credit: Int,
     val maxRegisteredUser: Int

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/LectureDateRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/LectureDateRequest.kt
@@ -1,0 +1,10 @@
+package team.msg.domain.lecture.presentation.data.request
+
+import java.time.LocalDate
+import java.time.LocalTime
+
+data class LectureDateRequest(
+    val completeDate: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
@@ -5,9 +5,12 @@ import team.msg.domain.lecture.enums.LectureStatus
 import team.msg.domain.lecture.enums.LectureType
 import team.msg.domain.lecture.enums.Semester
 import team.msg.domain.lecture.model.Lecture
+import team.msg.domain.lecture.model.LectureDate
 import team.msg.domain.user.enums.Authority
 import team.msg.domain.user.model.User
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.util.*
 
 data class LectureResponse(
@@ -20,7 +23,7 @@ data class LectureResponse(
     val line: String,
     val startDate: LocalDateTime,
     val endDate: LocalDateTime,
-    val completeDate: LocalDateTime,
+    val lectureDates: List<LectureDateResponse>,
     val lectureType: LectureType,
     val lectureStatus: LectureStatus,
     val headCount: Int,
@@ -28,7 +31,7 @@ data class LectureResponse(
     val lecturer: String
 ) {
     companion object {
-        fun of(lecture: Lecture, headCount: Int): LectureResponse = LectureResponse(
+        fun of(lecture: Lecture, headCount: Int, lectureDates: List<LectureDate>): LectureResponse = LectureResponse(
             id = lecture.id,
             name = lecture.name,
             content = lecture.content,
@@ -38,7 +41,7 @@ data class LectureResponse(
             line = lecture.line,
             startDate = lecture.startDate,
             endDate = lecture.endDate,
-            completeDate = lecture.completeDate,
+            lectureDates = of(lectureDates),
             lectureType = lecture.lectureType,
             lectureStatus = lecture.getLectureStatus(),
             headCount = headCount,
@@ -46,7 +49,7 @@ data class LectureResponse(
             lecturer = lecture.instructor
         )
 
-        fun detailOf(lecture: Lecture, headCount: Int, isRegistered: Boolean): LectureDetailsResponse = LectureDetailsResponse(
+        fun detailOf(lecture: Lecture, headCount: Int, isRegistered: Boolean, lectureDates: List<LectureDate>): LectureDetailsResponse = LectureDetailsResponse(
             name = lecture.name,
             content = lecture.content,
             semester = lecture.semester,
@@ -56,7 +59,7 @@ data class LectureResponse(
             createAt = lecture.createdAt,
             startDate = lecture.startDate,
             endDate = lecture.endDate,
-            completeDate = lecture.completeDate,
+            lectureDates = of(lectureDates),
             lectureType = lecture.lectureType,
             lectureStatus = lecture.getLectureStatus(),
             headCount = headCount,
@@ -64,6 +67,15 @@ data class LectureResponse(
             isRegistered = isRegistered,
             lecturer = lecture.instructor,
             credit = lecture.credit
+        )
+
+        fun of(lectureDates: List<LectureDate>): List<LectureDateResponse> =
+            lectureDates.map { of(it) }
+
+        fun of(lectureDate: LectureDate): LectureDateResponse = LectureDateResponse(
+            completeDate = lectureDate.completeDate,
+            startTime = lectureDate.startTime,
+            endTime = lectureDate.endTime
         )
 
         fun instructorOf(user: User, organization: String): InstructorResponse = InstructorResponse(
@@ -97,7 +109,7 @@ data class LectureDetailsResponse(
     val createAt: LocalDateTime,
     val startDate: LocalDateTime,
     val endDate: LocalDateTime,
-    val completeDate: LocalDateTime,
+    val lectureDates: List<LectureDateResponse>,
     val lectureType: LectureType,
     val lectureStatus: LectureStatus,
     val headCount: Int,
@@ -105,6 +117,12 @@ data class LectureDetailsResponse(
     val isRegistered: Boolean,
     val lecturer: String,
     val credit: Int
+)
+
+data class LectureDateResponse(
+    val completeDate: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime
 )
 
 data class InstructorsResponse(

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
@@ -57,7 +57,7 @@ data class LectureResponse(
             createAt = lecture.createdAt,
             startDate = lecture.startDate,
             endDate = lecture.endDate,
-            lectureDates = of(lectureDates),
+            lectureDates = dateListOf(lectureDates),
             lectureType = lecture.lectureType,
             lectureStatus = lecture.getLectureStatus(),
             headCount = headCount,
@@ -67,10 +67,10 @@ data class LectureResponse(
             credit = lecture.credit
         )
 
-        fun of(lectureDates: List<LectureDate>): List<LectureDateResponse> =
-            lectureDates.map { of(it) }
+        fun dateListOf(lectureDates: List<LectureDate>): List<LectureDateResponse> =
+            lectureDates.map { dateOf(it) }
 
-        fun of(lectureDate: LectureDate): LectureDateResponse = LectureDateResponse(
+        fun dateOf(lectureDate: LectureDate): LectureDateResponse = LectureDateResponse(
             completeDate = lectureDate.completeDate,
             startTime = lectureDate.startTime,
             endTime = lectureDate.endTime

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
@@ -23,7 +23,6 @@ data class LectureResponse(
     val line: String,
     val startDate: LocalDateTime,
     val endDate: LocalDateTime,
-    val lectureDates: List<LectureDateResponse>,
     val lectureType: LectureType,
     val lectureStatus: LectureStatus,
     val headCount: Int,
@@ -31,7 +30,7 @@ data class LectureResponse(
     val lecturer: String
 ) {
     companion object {
-        fun of(lecture: Lecture, headCount: Int, lectureDates: List<LectureDate>): LectureResponse = LectureResponse(
+        fun of(lecture: Lecture, headCount: Int): LectureResponse = LectureResponse(
             id = lecture.id,
             name = lecture.name,
             content = lecture.content,
@@ -41,7 +40,6 @@ data class LectureResponse(
             line = lecture.line,
             startDate = lecture.startDate,
             endDate = lecture.endDate,
-            lectureDates = of(lectureDates),
             lectureType = lecture.lectureType,
             lectureStatus = lecture.getLectureStatus(),
             headCount = headCount,

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/CreateLectureWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/CreateLectureWebRequest.kt
@@ -3,6 +3,7 @@ package team.msg.domain.lecture.presentation.data.web
 import com.fasterxml.jackson.annotation.JsonFormat
 import javax.persistence.EnumType
 import javax.persistence.Enumerated
+import javax.validation.Valid
 import javax.validation.constraints.Future
 import javax.validation.constraints.FutureOrPresent
 import javax.validation.constraints.Max
@@ -49,10 +50,9 @@ data class CreateLectureWebRequest(
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
     val endDate: LocalDateTime,
 
+    @Valid
     @field:NotNull
-    @Future
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    val completeDate: LocalDateTime,
+    val lectureDates: List<LectureDateWebRequest>,
 
     @field:NotNull
     @Enumerated(EnumType.STRING)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/LectureDateWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/LectureDateWebRequest.kt
@@ -1,0 +1,24 @@
+package team.msg.domain.lecture.presentation.data.web
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import javax.validation.constraints.Future
+import javax.validation.constraints.NotNull
+import java.time.LocalDate
+import java.time.LocalTime
+
+data class LectureDateWebRequest(
+    @field:NotNull
+    @Future
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    val completeDate: LocalDate,
+
+    @field:NotNull
+    @Future
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    val startTime: LocalTime,
+
+    @field:NotNull
+    @Future
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    val endTime: LocalTime
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/LectureDateWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/LectureDateWebRequest.kt
@@ -13,12 +13,10 @@ data class LectureDateWebRequest(
     val completeDate: LocalDate,
 
     @field:NotNull
-    @Future
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
     val startTime: LocalTime,
 
     @field:NotNull
-    @Future
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
     val endTime: LocalTime
 )

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/Lecture.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/Lecture.kt
@@ -49,9 +49,6 @@ class Lecture(
     @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
     val endDate: LocalDateTime,
 
-    @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
-    val completeDate: LocalDateTime,
-
     @Column(columnDefinition = "VARCHAR(1000)", nullable = false)
     val content: String,
 

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/LectureDate.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/LectureDate.kt
@@ -19,12 +19,12 @@ class LectureDate (
     @JoinColumn(name = "lecture_id", columnDefinition = "BINARY(16)")
     val lecture: Lecture,
 
-    @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
+    @Column(nullable = false, updatable = false, columnDefinition = "DATE")
     val completeDate: LocalDate,
 
-    @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
+    @Column(nullable = false, updatable = false, columnDefinition = "TIME")
     val startTime: LocalTime,
 
-    @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
+    @Column(nullable = false, updatable = false, columnDefinition = "TIME")
     val endTime: LocalTime,
 ) : BaseUUIDEntity(id)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/LectureDate.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/LectureDate.kt
@@ -1,0 +1,30 @@
+package team.msg.domain.lecture.model
+
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.FetchType
+import javax.persistence.JoinColumn
+import javax.persistence.ManyToOne
+import team.msg.common.entity.BaseUUIDEntity
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.*
+
+@Entity
+class LectureDate (
+    @get:JvmName("getIdentifier")
+    override var id: UUID,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "lecture_id", columnDefinition = "BINARY(16)")
+    val lecture: Lecture,
+
+    @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
+    val completeDate: LocalDate,
+
+    @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
+    val startTime: LocalTime,
+
+    @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
+    val endTime: LocalTime,
+) : BaseUUIDEntity(id)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/RegisteredLecture.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/RegisteredLecture.kt
@@ -1,13 +1,11 @@
 package team.msg.domain.lecture.model
 
-import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.FetchType
 import javax.persistence.JoinColumn
 import javax.persistence.ManyToOne
 import team.msg.common.entity.BaseUUIDEntity
 import team.msg.domain.student.model.Student
-import java.time.LocalDateTime
 import java.util.UUID
 
 @Entity
@@ -22,8 +20,5 @@ class RegisteredLecture(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "lecture_id", columnDefinition = "BINARY(16)")
-    val lecture: Lecture,
-
-    @Column(nullable = false, updatable = false, columnDefinition = "DATETIME(6)")
-    val completeDate: LocalDateTime
+    val lecture: Lecture
 ) : BaseUUIDEntity(id)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/LectureDateRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/LectureDateRepository.kt
@@ -1,0 +1,7 @@
+package team.msg.domain.lecture.repository
+
+import org.springframework.data.repository.CrudRepository
+import team.msg.domain.lecture.model.LectureDate
+import java.util.*
+
+interface LectureDateRepository : CrudRepository<LectureDate,UUID>

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/LectureDateRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/LectureDateRepository.kt
@@ -1,7 +1,10 @@
 package team.msg.domain.lecture.repository
 
 import org.springframework.data.repository.CrudRepository
+import team.msg.domain.lecture.model.Lecture
 import team.msg.domain.lecture.model.LectureDate
 import java.util.*
 
-interface LectureDateRepository : CrudRepository<LectureDate,UUID>
+interface LectureDateRepository : CrudRepository<LectureDate,UUID> {
+    fun findAllByLecture(lecture: Lecture): List<LectureDate>
+}


### PR DESCRIPTION
## 💡 개요
강의 수강일을 적용했습니다.

## 📃 작업내용
강의 일자 테이블을 작성했습니다.
- 강의 일자 테이블에는 강의 날짜, 강의 시작 시간 및 종료 시간이 포함되어있습니다.

강의 테스트 코드에도 변경점을 적용해주었습니다.

## 🔀 변경사항
- 수강 테이블에서 completeDate가 불필요해 삭제했습니다.