### PR TITLE
🔀  :: 어드민 학생활동 학생 단위로 조회 접근 허용

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -74,7 +74,7 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.DELETE, "/activity/{id}").hasAnyRole(STUDENT, TEACHER, BBOZZAK)
             .mvcMatchers(HttpMethod.GET, "/activity").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/activity/my").hasRole(STUDENT)
-            .mvcMatchers(HttpMethod.GET, "/activity/{student_id}").hasAnyRole(TEACHER, BBOZZAK)
+            .mvcMatchers(HttpMethod.GET, "/activity/{student_id}").hasAnyRole(TEACHER, ADMIN)
             .mvcMatchers(HttpMethod.GET, "/activity/{id}/detail").hasAnyRole(STUDENT, TEACHER, ADMIN, BBOZZAK)
 
             // post


### PR DESCRIPTION
## 💡 개요
어드민이 학생활동 학생 단위로 조회 시 401이 발생하던 문제를 수정하였습니다
## 📃 작업내용
securityconfig에 작성된 학생활동 학생 단위로 조회 uri pattern 어드민도 접근 가능하도록 수정
