### PR TITLE
이메일 인증 링크 클릭 시 blank 페이지가 띄워지던 오류

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/email/presentation/EmailController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/email/presentation/EmailController.kt
@@ -26,8 +26,8 @@ class EmailController(
     }
 
     @GetMapping("/authentication")
-    fun emailAuthentication(@RequestParam email: String, @RequestParam code: String): ResponseEntity<Unit> {
+    fun emailAuthentication(@RequestParam email: String, @RequestParam code: String): ResponseEntity<String> {
         emailService.emailAuthentication(email, code)
-        return ResponseEntity.noContent().build()
+        return ResponseEntity.ok("인증이 완료되었습니다.")
     }
 }


### PR DESCRIPTION
## 💡 개요
이메일 인증 링크 클릭 시 blank 페이지가 띄워지던 오류를 고쳤습니다.

## 📃 작업내용
- 인증 완료 후 문자열을 띄워 해결해주었어요!