### PR TITLE
인증된 이메일 계정 비밀번호 변경

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/mapper/AuthRequestMapper.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/mapper/AuthRequestMapper.kt
@@ -11,4 +11,5 @@ interface AuthRequestMapper {
     fun governmentSignUpWebRequestToDto(webRequest: GovernmentSignUpWebRequest): GovernmentSignUpRequest
     fun companyInstructorSignUpWebRequestToDto(webRequest: CompanyInstructorSignUpWebRequest): CompanyInstructorSignUpRequest
     fun loginWebRequestToDto(webRequest: LoginWebRequest): LoginRequest
+    fun changePasswordWebRequestToDto(webRequest: ChangePasswordWebRequest): ChangePasswordRequest
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/mapper/AuthRequestMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/mapper/AuthRequestMapperImpl.kt
@@ -100,4 +100,10 @@ class AuthRequestMapperImpl : AuthRequestMapper {
             email = webRequest.email,
             password = webRequest.password
         )
+
+    override fun changePasswordWebRequestToDto(webRequest: ChangePasswordWebRequest): ChangePasswordRequest =
+        ChangePasswordRequest(
+            email = webRequest.email,
+            newPassword = webRequest.newPassword
+        )
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/AuthController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/AuthController.kt
@@ -64,6 +64,13 @@ class AuthController(
         return ResponseEntity.ok(response)
     }
 
+    @PatchMapping("/password")
+    fun changePassword(@RequestBody @Valid webRequest: ChangePasswordWebRequest): ResponseEntity<Unit> {
+        val request = authRequestMapper.changePasswordWebRequestToDto(webRequest)
+        authService.changePassword(request)
+        return ResponseEntity.noContent().build()
+    }
+
     @PatchMapping
     fun reissueToken(@RequestHeader("RefreshToken") refreshToken: String): ResponseEntity<TokenResponse> {
         val response = authService.reissueToken(refreshToken)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/data/request/ChangePasswordRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/data/request/ChangePasswordRequest.kt
@@ -1,0 +1,6 @@
+package team.msg.domain.auth.presentation.data.request
+
+data class ChangePasswordRequest(
+    val email: String,
+    val newPassword: String
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/data/web/ChangePasswordWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/data/web/ChangePasswordWebRequest.kt
@@ -1,0 +1,14 @@
+package team.msg.domain.auth.presentation.data.web
+
+import javax.validation.constraints.Email
+import javax.validation.constraints.NotNull
+import javax.validation.constraints.Pattern
+
+data class ChangePasswordWebRequest(
+    @field:Email
+    @field:NotNull
+    val email: String,
+
+    @field:Pattern(regexp = "^(?=.*[A-Za-z0-9])[A-Za-z0-9!@#\\\\\$%^&*]{8,24}\$")
+    val newPassword: String
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthService.kt
@@ -1,9 +1,14 @@
 package team.msg.domain.auth.service
 
-import team.msg.domain.auth.presentation.data.request.*
-import team.msg.domain.auth.presentation.data.response.TokenResponse
 import team.msg.domain.auth.presentation.data.request.BbozzakSignUpRequest
-import team.msg.domain.auth.presentation.data.web.ChangePasswordWebRequest
+import team.msg.domain.auth.presentation.data.request.ChangePasswordRequest
+import team.msg.domain.auth.presentation.data.request.CompanyInstructorSignUpRequest
+import team.msg.domain.auth.presentation.data.request.GovernmentSignUpRequest
+import team.msg.domain.auth.presentation.data.request.LoginRequest
+import team.msg.domain.auth.presentation.data.request.ProfessorSignUpRequest
+import team.msg.domain.auth.presentation.data.request.StudentSignUpRequest
+import team.msg.domain.auth.presentation.data.request.TeacherSignUpRequest
+import team.msg.domain.auth.presentation.data.response.TokenResponse
 
 interface AuthService {
     fun studentSignUp(studentSignUpRequest: StudentSignUpRequest)
@@ -15,6 +20,6 @@ interface AuthService {
     fun login(request: LoginRequest): TokenResponse
     fun reissueToken(refreshToken: String): TokenResponse
     fun logout(refreshToken: String)
-    fun changePassword(changePasswordRequest: ChangePasswordRequest): ChangePasswordWebRequest
+    fun changePassword(changePasswordRequest: ChangePasswordRequest)
     fun withdraw()
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthService.kt
@@ -3,6 +3,7 @@ package team.msg.domain.auth.service
 import team.msg.domain.auth.presentation.data.request.*
 import team.msg.domain.auth.presentation.data.response.TokenResponse
 import team.msg.domain.auth.presentation.data.request.BbozzakSignUpRequest
+import team.msg.domain.auth.presentation.data.web.ChangePasswordWebRequest
 
 interface AuthService {
     fun studentSignUp(studentSignUpRequest: StudentSignUpRequest)
@@ -14,5 +15,6 @@ interface AuthService {
     fun login(request: LoginRequest): TokenResponse
     fun reissueToken(refreshToken: String): TokenResponse
     fun logout(refreshToken: String)
+    fun changePassword(changePasswordRequest: ChangePasswordRequest): ChangePasswordWebRequest
     fun withdraw()
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -272,6 +272,11 @@ class AuthServiceImpl(
         refreshTokenRepository.delete(token)
     }
 
+    /**
+     * 이메일이 인증된 사용자의 비밀번호를 변경하는 비지니스 로직입니다.
+     * @param 비밀번호를 변경할 계정의 이메일과 변경할 비밀번호
+     */
+    @Transactional(rollbackFor = [Exception::class])
     override fun changePassword(changePasswordRequest: ChangePasswordRequest) {
         val user = userRepository.findByEmail(changePasswordRequest.email)
             ?: throw UserNotFoundException("존재하지 않는 유저입니다. info : [ email =  ${changePasswordRequest.email} ]")

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -55,6 +55,7 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.POST, "/auth/government").permitAll()
             .mvcMatchers(HttpMethod.POST, "/auth/company-instructor").permitAll()
             .mvcMatchers(HttpMethod.POST, "/auth/login").permitAll()
+            .mvcMatchers(HttpMethod.PATCH, "/auth/password").permitAll()
             .mvcMatchers(HttpMethod.PATCH, "/auth").permitAll()
             .mvcMatchers(HttpMethod.DELETE, "/auth").authenticated()
             .mvcMatchers(HttpMethod.DELETE, "/auth/withdraw").authenticated()


### PR DESCRIPTION
## 💡 개요
인증된 계정의 비밀번호를 변경하는 api를 작성했습니다.

## 📃 작업내용
- 해당 이메일을 가진 유저가 없을 때 예외를 반환합니다.
- 이메일 인증이 만료되거나 이메일 인증 절차를 밟은 적 없는 계정이라면 예외를 반환합니다.
