### PR TITLE
이메일 새로 전송 시 코드 새로 발급

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/email/service/EmailServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/email/service/EmailServiceImpl.kt
@@ -51,6 +51,7 @@ class EmailServiceImpl(
 
         val updatedEmailAuthentication = emailAuthentication.copy(
             isAuthentication = false,
+            code = code,
             attemptCount = emailAuthentication.attemptCount + 1
         )
 


### PR DESCRIPTION
## 💡 개요
이메일을 새로 전송할 때 코드가 새로 발급되지 않던 문제를 해결했습니다.

## 📃 작업내용

## 🔀 변경사항
이메일 전송 시 코드를 새로 저장하도록 변경했습니다.

## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
