### PR TITLE
🔀 :: 327 강의 수강신청 동시성 문제 해결

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/RegisteredLectureService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/RegisteredLectureService.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.lecture.service
+
+import team.msg.domain.lecture.model.Lecture
+import team.msg.domain.student.model.Student
+
+interface RegisteredLectureService {
+    fun validateRegisterLectureCondition(student: Student, lecture: Lecture)
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/RegisteredLectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/RegisteredLectureServiceImpl.kt
@@ -1,0 +1,32 @@
+package team.msg.domain.lecture.service
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import team.msg.domain.lecture.enums.LectureStatus
+import team.msg.domain.lecture.exception.AlreadySignedUpLectureException
+import team.msg.domain.lecture.exception.NotAvailableSignUpDateException
+import team.msg.domain.lecture.exception.OverMaxRegisteredUserException
+import team.msg.domain.lecture.model.Lecture
+import team.msg.domain.lecture.repository.RegisteredLectureRepository
+import team.msg.domain.student.model.Student
+import java.time.LocalDateTime
+
+@Service
+class RegisteredLectureServiceImpl(
+    private val registeredLectureRepository: RegisteredLectureRepository
+) : RegisteredLectureService {
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    override fun validateRegisterLectureCondition(student: Student, lecture: Lecture) {
+        if(lecture.getLectureStatus() == LectureStatus.CLOSED)
+            throw NotAvailableSignUpDateException("수강신청이 가능한 시간이 아닙니다. info : [ lectureId = ${lecture.id}, currentTime = ${LocalDateTime.now()} ]")
+
+        if(registeredLectureRepository.existsOne(student.id, lecture.id))
+            throw AlreadySignedUpLectureException("이미 신청한 강의입니다. info : [ lectureId = ${lecture.id}, studentId = ${student.id} ]")
+
+        val currentSignUpLectureStudent = registeredLectureRepository.countRegisteredLectureByLecture(lecture)
+
+        if(lecture.maxRegisteredUser <= currentSignUpLectureStudent)
+            throw OverMaxRegisteredUserException("수강 인원이 가득 찼습니다. info : [ maxRegisteredUser = ${lecture.maxRegisteredUser}, currentSignUpLectureStudent = $currentSignUpLectureStudent ]")
+    }
+}

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
@@ -29,11 +29,7 @@ import team.msg.domain.lecture.presentation.data.request.CreateLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllDepartmentsRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLinesRequest
-import team.msg.domain.lecture.presentation.data.response.InstructorsResponse
-import team.msg.domain.lecture.presentation.data.response.LectureDateResponse
-import team.msg.domain.lecture.presentation.data.response.LectureDetailsResponse
-import team.msg.domain.lecture.presentation.data.response.LectureResponse
-import team.msg.domain.lecture.presentation.data.response.LecturesResponse
+import team.msg.domain.lecture.presentation.data.response.*
 import team.msg.domain.lecture.repository.LectureDateRepository
 import team.msg.domain.lecture.repository.LectureRepository
 import team.msg.domain.lecture.repository.RegisteredLectureRepository
@@ -65,6 +61,7 @@ class LectureServiceImplTest : BehaviorSpec({
     val professorRepository = mockk<ProfessorRepository>()
     val userRepository = mockk<UserRepository>()
     val userUtil = mockk<UserUtil>()
+    val registeredLectureService = mockk<RegisteredLectureService>()
     val pageable = mockk<Pageable>()
     val lectureServiceImpl = LectureServiceImpl(
         lectureRepository,
@@ -74,7 +71,8 @@ class LectureServiceImplTest : BehaviorSpec({
         teacherRepository,
         professorRepository,
         userRepository,
-        userUtil
+        userUtil,
+        registeredLectureService
     )
 
     // createLecture 테스트 코드

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/RegisteredLectureRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/RegisteredLectureRepository.kt
@@ -1,7 +1,11 @@
 package team.msg.domain.lecture.repository
 
+import javax.persistence.LockModeType
+import javax.persistence.QueryHint
 import org.springframework.data.jpa.repository.EntityGraph
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jpa.repository.QueryHints
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.lecture.model.Lecture
 import team.msg.domain.lecture.model.RegisteredLecture
@@ -19,4 +23,6 @@ interface RegisteredLectureRepository : CrudRepository<RegisteredLecture, UUID>,
     fun countByLecture(lecture: Lecture): Int
     @EntityGraph(attributePaths = ["student"])
     fun findAllByLecture(lecture: Lecture): List<RegisteredLecture>
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    fun countRegisteredLectureByLecture(lecture: Lecture): Int
 }


### PR DESCRIPTION
## 💡 개요
강의 수강을 동시에 신청했을 시 강의 수강 인원이 초과되어 신청되는 문제가 발생하여 이를 해결하였습니다
## 📃 작업내용
기존에 수강 신청 인원을 COUNT하는 쿼리에 비관적 락인 PESSIMISTIC_WRITE(SELECT ... FOR UPDATE)를 사용하여 두번의 갱실 문제 중 최초 커밋만 인정할 수 있도록 동시성을 제어하려 하였지만 예상했던 결과와 다르게 동시로 보낸 여러 요청 중 하나의 요청 빼고는 전부 실패하였습니다

이는 트랜잭션을 진행하던 도중 다음과 같은 경우에 의해 발생했던 것입니다
* 테이블의 레코드가 0개이며, SELECT ... FOR UPDATE 쿼리로 조회한 데이터가 0개인 경우
> 강의 신청이 시작되는 직후 다음과 같은 문제가 발생하였습니다
* 설령 테이블에 레코드가 존재한다 하더라도 둘 이상의 세션이 SELECT ... FOR UPDATE로 같은 id에 접근하는 경우
> 이는 같은 강의를 동시에 신청하는 경우에 발생하였습니다

이 두가지 경우는 모든 세션에서 INSERT문을 실행하지 못하게 되어 DeadLock이 발생하는 DB Level Issue가 있기 때문입니다

이를 해결하기 위해 수강 신청 인원을 COUNT 하는 쿼리를 @Lock(LockModeType.PESSIMISTIC_WRITE)옵션을 사용하며 DeadLock을 피하기 위해서 위의 로직을 새로운 클래스인 RegisteredLectureService로 옮긴 후 @Transactional(propagation = Propagation.REQUIRED_NEW)를 사용하여 새로운 트랜잭션을 실행하도록 하여 해결했습니다

해당 MySQL 이슈에 대한 참고글입니다
[링크](https://soohyeon317.tistory.com/entry/SELECT-FOR-UPDATE-%EB%AC%B8-%EA%B4%80%EB%A0%A8-Dead-Lock-%EB%AC%B8%EC%A0%9C)