### PR TITLE
# 370 탈퇴 예정자 리스트 조회 시 인자 추가 반환

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/withdraw/presentation/data/response/WithdrawStudentResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/withdraw/presentation/data/response/WithdrawStudentResponse.kt
@@ -6,7 +6,7 @@ import java.util.UUID
 data class WithdrawStudentResponse(
     val withdrawId: Long,
     val userId: UUID,
-    val studentName: String,
+    val name: String,
     val email: String,
     val phoneNumber: String
 ) {
@@ -14,7 +14,7 @@ data class WithdrawStudentResponse(
         fun of(withdraw: WithdrawStudent) = WithdrawStudentResponse(
             withdrawId = withdraw.id,
             userId = withdraw.student.user!!.id,
-            studentName = withdraw.student.user!!.name,
+            name = withdraw.student.user!!.name,
             email = withdraw.student.user!!.email,
             phoneNumber = withdraw.student.user!!.phoneNumber
         )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/withdraw/presentation/data/response/WithdrawStudentResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/withdraw/presentation/data/response/WithdrawStudentResponse.kt
@@ -6,13 +6,17 @@ import java.util.UUID
 data class WithdrawStudentResponse(
     val withdrawId: Long,
     val userId: UUID,
-    val studentName: String
+    val studentName: String,
+    val email: String,
+    val phoneNumber: String
 ) {
     companion object {
         fun of(withdraw: WithdrawStudent) = WithdrawStudentResponse(
             withdrawId = withdraw.id,
             userId = withdraw.student.user!!.id,
-            studentName = withdraw.student.user!!.name
+            studentName = withdraw.student.user!!.name,
+            email = withdraw.student.user!!.email,
+            phoneNumber = withdraw.student.user!!.phoneNumber
         )
 
         fun listOf(students: List<WithdrawStudent>) = WithdrawStudentResponses(


### PR DESCRIPTION
## 💡 배경 및 개요

탈퇴 예정자 리스트 조회 시 인자 추가 반환
> 디자인 변경 사항에 따른 인자 추가해 주었습니다.

Resolves: #{370}

## 📃 작업내용

이메일, 전화 번호 추가 했습니다.