### PR TITLE
강의 구분 검색 api를 작성했습니다.

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/mapper/LectureRequestMapper.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/mapper/LectureRequestMapper.kt
@@ -4,8 +4,10 @@ import team.msg.domain.lecture.presentation.data.request.CreateLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllDepartmentsRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLinesRequest
+import team.msg.domain.lecture.presentation.data.request.QueryAllDivisionsRequest
 import team.msg.domain.lecture.presentation.data.web.CreateLectureWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllDepartmentsWebRequest
+import team.msg.domain.lecture.presentation.data.web.QueryAllDivisionsWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllLecturesWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllLinesWebRequest
 
@@ -14,4 +16,5 @@ interface LectureRequestMapper {
     fun queryLectureWebRequestToDto(webRequest: QueryAllLecturesWebRequest): QueryAllLectureRequest
     fun queryAllLinesWebRequestToDto(webRequest: QueryAllLinesWebRequest): QueryAllLinesRequest
     fun queryAllDepartmentsWebRequestToDto(webRequest: QueryAllDepartmentsWebRequest): QueryAllDepartmentsRequest
+    fun queryAllDivisionsWebRequestToDto(webRequest: QueryAllDivisionsWebRequest): QueryAllDivisionsRequest
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/mapper/LectureRequestMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/mapper/LectureRequestMapperImpl.kt
@@ -4,11 +4,13 @@ import org.springframework.stereotype.Component
 import team.msg.domain.lecture.presentation.data.request.CreateLectureRequest
 import team.msg.domain.lecture.presentation.data.request.LectureDateRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllDepartmentsRequest
+import team.msg.domain.lecture.presentation.data.request.QueryAllDivisionsRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLinesRequest
 import team.msg.domain.lecture.presentation.data.web.CreateLectureWebRequest
 import team.msg.domain.lecture.presentation.data.web.LectureDateWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllDepartmentsWebRequest
+import team.msg.domain.lecture.presentation.data.web.QueryAllDivisionsWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllLecturesWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllLinesWebRequest
 
@@ -61,6 +63,13 @@ class LectureRequestMapperImpl : LectureRequestMapper{
      * 학과 조회 Web Request 를 애플리케이션 영역에서 사용될 Dto 로 매핑합니다.
      */
     override fun queryAllDepartmentsWebRequestToDto(webRequest: QueryAllDepartmentsWebRequest) = QueryAllDepartmentsRequest(
+        keyword = webRequest.keyword
+    )
+
+    /**
+     * 구분 조회 Web Request 를 애플리케이션 영역에서 사용될 Dto 로 매핑합니다.
+     */
+    override fun queryAllDivisionsWebRequestToDto(webRequest: QueryAllDivisionsWebRequest) = QueryAllDivisionsRequest(
         keyword = webRequest.keyword
     )
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
@@ -3,9 +3,7 @@ package team.msg.domain.lecture.presentation
 import javax.servlet.http.HttpServletResponse
 import javax.validation.Valid
 import org.springframework.data.domain.Pageable
-import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -17,12 +15,14 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.msg.domain.lecture.mapper.LectureRequestMapper
 import team.msg.domain.lecture.presentation.data.response.DepartmentsResponse
+import team.msg.domain.lecture.presentation.data.response.DivisionsResponse
 import team.msg.domain.lecture.presentation.data.response.InstructorsResponse
 import team.msg.domain.lecture.presentation.data.response.LecturesResponse
 import team.msg.domain.lecture.presentation.data.response.LectureDetailsResponse
 import team.msg.domain.lecture.presentation.data.response.LinesResponse
 import team.msg.domain.lecture.presentation.data.web.CreateLectureWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllDepartmentsWebRequest
+import team.msg.domain.lecture.presentation.data.web.QueryAllDivisionsWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllLecturesWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllLinesWebRequest
 import team.msg.domain.lecture.service.LectureService
@@ -83,6 +83,13 @@ class LectureController(
     fun queryAllDepartments(webRequest: QueryAllDepartmentsWebRequest): ResponseEntity<DepartmentsResponse> {
         val request = lectureRequestMapper.queryAllDepartmentsWebRequestToDto(webRequest)
         val response = lectureService.queryAllDepartments(request)
+        return ResponseEntity.status(HttpStatus.OK).body(response)
+    }
+
+    @GetMapping("/division")
+    fun queryAllDivisions(webRequest: QueryAllDivisionsWebRequest): ResponseEntity<DivisionsResponse> {
+        val request = lectureRequestMapper.queryAllDivisionsWebRequestToDto(webRequest)
+        val response = lectureService.queryAllDivisions(request)
         return ResponseEntity.status(HttpStatus.OK).body(response)
     }
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/QueryAllDivisionsRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/request/QueryAllDivisionsRequest.kt
@@ -1,0 +1,5 @@
+package team.msg.domain.lecture.presentation.data.request
+
+class QueryAllDivisionsRequest(
+    val keyword: String?
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/response/LectureResponse.kt
@@ -88,6 +88,10 @@ data class LectureResponse(
         fun departmentOf(departments: List<String>): DepartmentsResponse = DepartmentsResponse(
             departments = departments
         )
+
+        fun divisionOf(divisions: List<String>): DivisionsResponse = DivisionsResponse(
+            divisions = divisions
+        )
     }
 }
 
@@ -138,4 +142,8 @@ data class LinesResponse(
 
 data class DepartmentsResponse(
     val departments: List<String>
+)
+
+data class DivisionsResponse(
+    val divisions: List<String>
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/QueryAllDivisionsWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/QueryAllDivisionsWebRequest.kt
@@ -1,0 +1,8 @@
+package team.msg.domain.lecture.presentation.data.web
+
+import org.springframework.web.bind.annotation.RequestParam
+
+data class QueryAllDivisionsWebRequest(
+    @RequestParam(required = false)
+    val keyword: String? = null
+)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureService.kt
@@ -4,9 +4,11 @@ import javax.servlet.http.HttpServletResponse
 import org.springframework.data.domain.Pageable
 import team.msg.domain.lecture.presentation.data.request.CreateLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllDepartmentsRequest
+import team.msg.domain.lecture.presentation.data.request.QueryAllDivisionsRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLinesRequest
 import team.msg.domain.lecture.presentation.data.response.DepartmentsResponse
+import team.msg.domain.lecture.presentation.data.response.DivisionsResponse
 import team.msg.domain.lecture.presentation.data.response.InstructorsResponse
 import team.msg.domain.lecture.presentation.data.response.LecturesResponse
 import team.msg.domain.lecture.presentation.data.response.LectureDetailsResponse
@@ -19,6 +21,7 @@ interface LectureService {
     fun queryLectureDetails(id: UUID): LectureDetailsResponse
     fun queryAllLines(request: QueryAllLinesRequest): LinesResponse
     fun queryAllDepartments(request: QueryAllDepartmentsRequest): DepartmentsResponse
+    fun queryAllDivisions(request: QueryAllDivisionsRequest): DivisionsResponse
     fun signUpLecture(id: UUID)
     fun cancelSignUpLecture(id: UUID)
     fun queryInstructors(keyword: String): InstructorsResponse

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -23,9 +23,11 @@ import team.msg.domain.lecture.model.LectureDate
 import team.msg.domain.lecture.model.RegisteredLecture
 import team.msg.domain.lecture.presentation.data.request.CreateLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllDepartmentsRequest
+import team.msg.domain.lecture.presentation.data.request.QueryAllDivisionsRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLinesRequest
 import team.msg.domain.lecture.presentation.data.response.DepartmentsResponse
+import team.msg.domain.lecture.presentation.data.response.DivisionsResponse
 import team.msg.domain.lecture.presentation.data.response.InstructorsResponse
 import team.msg.domain.lecture.presentation.data.response.LectureDetailsResponse
 import team.msg.domain.lecture.presentation.data.response.LectureResponse
@@ -173,6 +175,20 @@ class LectureServiceImpl(
     override fun queryAllDepartments(request: QueryAllDepartmentsRequest): DepartmentsResponse {
         val departments = lectureRepository.findAllDepartment(request.keyword)
         val response = LectureResponse.departmentOf(departments)
+
+        return response
+    }
+
+    /**
+     * 서버에 저장된 구분 리스트를 조회하는 비지니스 로직입니다.
+     * 키워드를 통해 필터링 합니다.
+     * @param 키워드
+     * @return 구분 리스트 response
+     */
+    @Transactional(readOnly = true)
+    override fun queryAllDivisions(request: QueryAllDivisionsRequest): DivisionsResponse {
+        val divisions = lectureRepository.findAllDivisions(request.keyword)
+        val response = LectureResponse.divisionOf(divisions)
 
         return response
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -100,6 +100,7 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.GET, "/lecture/instructor").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/lecture/line").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/lecture/department").hasRole(ADMIN)
+            .mvcMatchers(HttpMethod.GET, "/lecture/division").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/lecture/excel").hasRole(ADMIN)
 
             // faq

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/CustomLectureRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/CustomLectureRepository.kt
@@ -10,4 +10,5 @@ interface CustomLectureRepository {
     fun deleteAllByUserId(userId: UUID)
     fun findAllLineByDivision(division: String, keyword: String?): List<String>
     fun findAllDepartment(keyword: String?): List<String>
+    fun findAllDivisions(keyword: String?): List<String>
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomLectureRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomLectureRepositoryImpl.kt
@@ -64,6 +64,14 @@ class CustomLectureRepositoryImpl(
             .fetch()
             .distinct()
 
+    override fun findAllDivisions(keyword: String?): List<String> =
+        queryFactory
+            .select(lecture.division)
+            .from(lecture)
+            .where(eqDivision(keyword))
+            .fetch()
+            .distinct()
+
     private fun eqLectureType(lectureType: String?): BooleanExpression? =
         if(isNull(lectureType)) null else lecture.lectureType.contains(lectureType)
 
@@ -71,4 +79,6 @@ class CustomLectureRepositoryImpl(
         if(keyword.isNullOrBlank()) null else lecture.line.contains(keyword)
     private fun eqDepartment(keyword: String?): BooleanExpression? =
         if(keyword.isNullOrBlank()) null else lecture.department.contains(keyword)
+    private fun eqDivision(keyword: String?): BooleanExpression? =
+        if(keyword.isNullOrBlank()) null else lecture.division.contains(keyword)
 }


### PR DESCRIPTION
## 💡 배경 및 개요

강의 구분을 사용자가 입력할 수 있도록 변경되었기에, 강의 구분 검색 api를 작성했습니다.

Resolves: #380 

## 📃 작업내용

- 서버에 저장된 강의의 division 리스트를 가져와 반환합니다.
- 다른 검색 api 로직과 같은 흐름으로 작동합니다!

## 🙋‍♂️ 리뷰노트

- 감사합니다

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
