### PR TITLE
# 376 유관기관 엔티티 필드 변경

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/mapper/AuthRequestMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/mapper/AuthRequestMapperImpl.kt
@@ -75,7 +75,9 @@ class AuthRequestMapperImpl : AuthRequestMapper {
             password = webRequest.password,
             highSchool = webRequest.highSchool,
             clubName = webRequest.clubName,
-            governmentName = webRequest.governmentName
+            governmentName = webRequest.governmentName,
+            position = webRequest.position,
+            sectors = webRequest.sectors
         )
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/data/request/GovernmentSignUpRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/data/request/GovernmentSignUpRequest.kt
@@ -9,5 +9,7 @@ data class GovernmentSignUpRequest(
     val password: String,
     val highSchool: HighSchool,
     val clubName: String,
-    val governmentName: String
+    val governmentName: String,
+    val position: String,
+    val sectors: String
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/data/web/GovernmentSignUpWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/data/web/GovernmentSignUpWebRequest.kt
@@ -31,5 +31,11 @@ data class GovernmentSignUpWebRequest(
     val clubName: String,
 
     @field:NotBlank
-    val governmentName: String
+    val governmentName: String,
+
+    @field:NotBlank
+    val position: String,
+
+    @field:NotBlank
+    val sectors: String
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -186,7 +186,9 @@ class AuthServiceImpl(
             id = UUID.randomUUID(),
             user = user,
             club = club,
-            governmentName = request.governmentName
+            governmentName = request.governmentName,
+            position = request.position,
+            sectors = request.sectors
         )
         governmentRepository.save(government)
     }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/government/model/Government.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/government/model/Government.kt
@@ -27,6 +27,12 @@ class Government(
     val club: Club,
 
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
-    val governmentName: String
+    val governmentName: String,
+
+    @Column(columnDefinition = "VARCHAR(20)", nullable = false)
+    val position: String,
+
+    @Column(columnDefinition = "VARCHAR(20)", nullable = false)
+    val sectors: String
 
 ) : BaseUUIDEntity(id)


### PR DESCRIPTION
## 💡 배경 및 개요

유관기관 엔티티 필드 변경

Resolves: #{376}

## 📃 작업내용

직책 필드를 position 이라는 변수명으로 추가했습니다.
업종 필드를 sectors 라는 변수명으로 추가했습니다.