### PR TITLE
# 387 JVM 웜업

### DIFF
--- a/bitgouel-api/build.gradle.kts
+++ b/bitgouel-api/build.gradle.kts
@@ -31,7 +31,14 @@ dependencies {
     implementation("io.micrometer:micrometer-registry-prometheus")
     implementation("ca.pjer:logback-awslogs-appender:1.6.0")
     implementation("com.github.napstr:logback-discord-appender:1.0.0")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
     implementation(project(":bitgouel-domain"))
+}
+
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:2021.0.5")
+    }
 }
 
 kapt {

--- a/bitgouel-api/src/main/kotlin/team/msg/global/warmup/WarmUpRunner.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/warmup/WarmUpRunner.kt
@@ -3,15 +3,15 @@ package team.msg.global.warmup
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.stereotype.Component
-import team.msg.thirdparty.feign.client.WarmUpClient
+import team.msg.thirdparty.feign.client.FaqClient
 
 @Component
 class WarmUpRunner(
-    private val warmUpClient: WarmUpClient
+    private val faqClient: FaqClient
 ): ApplicationRunner {
     override fun run(args: ApplicationArguments?) {
         runCatching {
-            warmUpClient.queryFaq()
+            faqClient.queryFaq()
         }.onFailure {  }
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/global/warmup/WarmUpRunner.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/warmup/WarmUpRunner.kt
@@ -10,6 +10,8 @@ class WarmUpRunner(
     private val warmUpClient: WarmUpClient
 ): ApplicationRunner {
     override fun run(args: ApplicationArguments?) {
-        warmUpClient.queryFaq()
+        runCatching {
+            warmUpClient.queryFaq()
+        }.onFailure {  }
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/global/warmup/WarmUpRunner.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/warmup/WarmUpRunner.kt
@@ -1,0 +1,15 @@
+package team.msg.global.warmup
+
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.stereotype.Component
+import team.msg.thirdparty.feign.client.WarmUpClient
+
+@Component
+class WarmUpRunner(
+    private val warmUpClient: WarmUpClient
+): ApplicationRunner {
+    override fun run(args: ApplicationArguments?) {
+        warmUpClient.queryFaq()
+    }
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/thirdparty/feign/client/FaqClient.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/thirdparty/feign/client/FaqClient.kt
@@ -4,8 +4,8 @@ import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.GetMapping
 import team.msg.domain.faq.presentation.data.response.FaqsResponse
 
-@FeignClient(value = "warmUp", url = "http://localhost:8080")
-interface WarmUpClient {
+@FeignClient(value = "faq", url = "http://localhost:8080")
+interface FaqClient {
 
     @GetMapping("/faq")
     fun queryFaq(): FaqsResponse

--- a/bitgouel-api/src/main/kotlin/team/msg/thirdparty/feign/client/WarmUpClient.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/thirdparty/feign/client/WarmUpClient.kt
@@ -1,0 +1,13 @@
+package team.msg.thirdparty.feign.client
+
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import team.msg.domain.faq.presentation.data.response.FaqsResponse
+
+@FeignClient(value = "warmUp", url = "http://localhost:8080")
+interface WarmUpClient {
+
+    @GetMapping("/faq")
+    fun queryFaq(): FaqsResponse
+
+}

--- a/bitgouel-api/src/main/kotlin/team/msg/thirdparty/feign/config/FeignConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/thirdparty/feign/config/FeignConfig.kt
@@ -1,0 +1,8 @@
+package team.msg.thirdparty.feign.config
+
+import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.context.annotation.Configuration
+
+@EnableFeignClients(basePackages = ["team.msg.thirdparty.feign"])
+@Configuration
+class FeignConfig

--- a/bitgouel-api/src/main/resources/application.yml
+++ b/bitgouel-api/src/main/resources/application.yml
@@ -54,4 +54,14 @@ management:
     web:
       exposure:
         include: health, info, metrics, prometheus
-    enabled-by-default: false
+#    enabled-by-default: false
+
+    endpoint:
+      health:
+        enabled: true
+
+      info:
+        enabled: true
+
+      prometheus:
+        enabled: true

--- a/bitgouel-api/src/main/resources/application.yml
+++ b/bitgouel-api/src/main/resources/application.yml
@@ -54,14 +54,14 @@ management:
     web:
       exposure:
         include: health, info, metrics, prometheus
-#    enabled-by-default: false
+    enabled-by-default: false
 
-    endpoint:
-      health:
-        enabled: true
+  endpoint:
+    health:
+      enabled: true
 
-      info:
-        enabled: true
+    info:
+      enabled: true
 
-      prometheus:
-        enabled: true
+    prometheus:
+      enabled: true

--- a/bitgouel-api/src/main/resources/application.yml
+++ b/bitgouel-api/src/main/resources/application.yml
@@ -54,6 +54,7 @@ management:
     web:
       exposure:
         include: health, info, metrics, prometheus
+      base-path: ${ACTUATOR_BASE_PATH:/actuator}
     enabled-by-default: false
 
   endpoint:

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/Student.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/Student.kt
@@ -13,7 +13,7 @@ import team.msg.common.entity.BaseUUIDEntity
 import team.msg.domain.club.model.Club
 import team.msg.domain.student.enums.StudentRole
 import team.msg.domain.user.model.User
-import java.util.UUID
+import java.util.*
 
 @Entity
 class Student(
@@ -48,5 +48,4 @@ class Student(
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
     val studentRole: StudentRole
 
-) : BaseUUIDEntity(id) {
-}
+) : BaseUUIDEntity(id)


### PR DESCRIPTION
## 💡 배경 및 개요

JVM 웜업

Resolves: #{387}

## 📃 작업내용

서비스 배포 직후 첫 요청에 대해 레이턴시가 발생합니다. 이유는 크게 두 가지입니다.

첫 번째, 클래스 로더가 애플리케이션이 시작될 때 로딩되는 것이 아닌 클래스가 필요한 시점까지 로딩을 지연하는 지연 로딩으로 작동합니다.
두 번째, JIT Compiler는 실행하는 과정에서 기계어로 변환하는 과정을 최적화 하기 위한 것입니다. 그러나, 애플리케이션이 처음 실행되는 시점에는 자주 사용되는 바이트코드가 캐시된 내역이 없기 때문에 성능 이슈가 발생합니다. 

자주 호출될 것으로 예상되는 API에 미리 요청을 보냄으로서 Warm-Up 하여 해결했습니다. (FAQ 조회 API를 메인 페이지에서 사용하기에 Warm Up 했습니다. 나중에 성능 테스트를 진행하면서 다른 API도 추가할 예정이며, 호출 횟수 또한 늘릴 가능성이 있습니다.)