### PR TITLE
강의 이수 여부 수정 api 작성

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -111,5 +112,14 @@ class LectureController(
     fun queryAllSignedUpStudents(@PathVariable id: UUID): ResponseEntity<SignedUpStudentsResponse> {
         val response = lectureService.queryAllSignedUpStudents(id)
         return ResponseEntity.status(HttpStatus.OK).body(response)
+    }
+
+    @PatchMapping("/{id}/{student_id}")
+    fun updateLectureCompleteStatus(
+        @PathVariable id: UUID, @PathVariable("student_id") studentId: UUID,
+        @RequestParam isComplete: Boolean
+    ): ResponseEntity<Unit> {
+        val response = lectureService.updateLectureCompleteStatus(id, studentId, isComplete)
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureService.kt
@@ -29,5 +29,6 @@ interface LectureService {
     fun queryInstructors(keyword: String): InstructorsResponse
     fun queryAllSignedUpLectures(studentId: UUID): SignedUpLecturesResponse
     fun queryAllSignedUpStudents(id: UUID): SignedUpStudentsResponse
+    fun updateLectureCompleteStatus(id: UUID, studentId: UUID, isComplete: Boolean)
     fun lectureReceiptStatusExcel(response: HttpServletResponse)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -402,9 +402,7 @@ class LectureServiceImpl(
                 if(bbozzak.club != student.club)
                     throw ForbiddenSignedUpLectureException("학생의 이수 여부를 변경할 권한이 없습니다. info : [ userId = ${user.id} ]")
             }
-            Authority.ROLE_ADMIN -> {
-
-            }
+            Authority.ROLE_ADMIN -> { }
             else -> {
                 val lecture = lectureRepository findById id
                 if (lecture.user != user)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -374,6 +374,26 @@ class LectureServiceImpl(
         return response
     }
 
+    /**
+     * 강의 수강 여부를 업데이트하는 비지니스 로직입니다.
+     *
+     * @param 이수 상태를 변경할 강의 id와 학생 id, 변결될 강의 여부
+     */
+    @Transactional(rollbackFor = [Exception::class])
+    override fun updateLectureCompleteStatus(id: UUID, studentId: UUID, isComplete: Boolean) {
+        val registeredLecture = registeredLectureRepository.findByLectureIdAndStudentId(id, studentId)
+            ?: throw UnSignedUpLectureException("학생의 강의 신청 기록을 찾을 수 없습니다. info : [ lectureId = $id, studentId = $studentId ]")
+        
+        val updatedRegisteredLecture = RegisteredLecture(
+            id = registeredLecture.id,
+            student = registeredLecture.student,
+            lecture = registeredLecture.lecture,
+            isComplete = isComplete
+        )
+
+        registeredLectureRepository.save(updatedRegisteredLecture)
+    }
+
     @Transactional(readOnly = true,rollbackFor = [Exception::class])
     override fun lectureReceiptStatusExcel(response: HttpServletResponse) {
         val workBook = XSSFWorkbook()

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -377,10 +377,41 @@ class LectureServiceImpl(
     /**
      * 강의 수강 여부를 업데이트하는 비지니스 로직입니다.
      *
+     * 기업 강사, 유관기관 강사, 대학 교수 -> 자기 강의 학생들만 변경할 수 있음 (다른 강사의 강의 학생 수강 여부 변경 시 예외)
+     * 뽀짝 선생님, 취업 동아리 선생님 -> 담당 동아리 소속 학생만 변경
+     * 어드민 -> 제한 없음
+     *
      * @param 이수 상태를 변경할 강의 id와 학생 id, 변결될 강의 여부
      */
     @Transactional(rollbackFor = [Exception::class])
     override fun updateLectureCompleteStatus(id: UUID, studentId: UUID, isComplete: Boolean) {
+        val user = userUtil.queryCurrentUser()
+
+        when(user.authority) {
+            Authority.ROLE_TEACHER -> {
+                val teacher = teacherRepository findByUser user
+                val student = studentRepository findById studentId
+
+                if(teacher.club != student.club)
+                    throw ForbiddenSignedUpLectureException("학생의 이수 여부를 변경할 권한이 없습니다. info : [ userId = ${user.id} ]")
+            }
+            Authority.ROLE_BBOZZAK -> {
+                val bbozzak = bbozzakRepository findByUser user
+                val student = studentRepository findById studentId
+
+                if(bbozzak.club != student.club)
+                    throw ForbiddenSignedUpLectureException("학생의 이수 여부를 변경할 권한이 없습니다. info : [ userId = ${user.id} ]")
+            }
+            Authority.ROLE_ADMIN -> {
+
+            }
+            else -> {
+                val lecture = lectureRepository findById id
+                if (lecture.user != user)
+                    throw ForbiddenSignedUpLectureException("학생의 이수 여부를 변경할 권한이 없습니다. info : [ userId = ${user.id} ]")
+            }
+        }
+
         val registeredLecture = registeredLectureRepository.findByLectureIdAndStudentId(id, studentId)
             ?: throw UnSignedUpLectureException("학생의 강의 신청 기록을 찾을 수 없습니다. info : [ lectureId = $id, studentId = $studentId ]")
         

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -103,6 +103,7 @@ class SecurityConfig(
             .mvcMatchers(HttpMethod.GET, "/lecture/department").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/lecture/{student_id}/signup").hasAnyRole(ADMIN, TEACHER)
             .mvcMatchers(HttpMethod.GET, "/lecture/student/{id}").hasAnyRole(ADMIN, TEACHER, BBOZZAK, COMPANY_INSTRUCTOR, PROFESSOR, GOVERNMENT)
+            .mvcMatchers(HttpMethod.PATCH, "/lecture/{id}/{student_id}").hasAnyRole(ADMIN, TEACHER, BBOZZAK, COMPANY_INSTRUCTOR, PROFESSOR, GOVERNMENT)
             .mvcMatchers(HttpMethod.GET, "/lecture/division").hasRole(ADMIN)
             .mvcMatchers(HttpMethod.GET, "/lecture/excel").hasRole(ADMIN)
 

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/CustomRegisteredLectureRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/CustomRegisteredLectureRepository.kt
@@ -1,6 +1,7 @@
 package team.msg.domain.lecture.repository.custom
 
 import team.msg.domain.lecture.model.Lecture
+import team.msg.domain.lecture.model.RegisteredLecture
 import team.msg.domain.student.model.Student
 import java.util.*
 
@@ -10,4 +11,5 @@ interface CustomRegisteredLectureRepository {
     fun findLecturesAndIsCompleteByStudentId(studentId: UUID): List<Pair<Lecture, Boolean>>
     fun findSignedUpStudentsByLectureId(lectureId: UUID): List<Student>
     fun findSignedUpStudentsByLectureIdAndClubId(lectureId: UUID, clubId: Long): List<Student>
+    fun findByLectureIdAndStudentId(lectureId: UUID, studentId: UUID): RegisteredLecture?
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomRegisteredLectureRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomRegisteredLectureRepositoryImpl.kt
@@ -5,6 +5,7 @@ import team.msg.domain.club.model.QClub.club
 import team.msg.domain.lecture.model.Lecture
 import team.msg.domain.lecture.model.QLecture.lecture
 import team.msg.domain.lecture.model.QRegisteredLecture.registeredLecture
+import team.msg.domain.lecture.model.RegisteredLecture
 import team.msg.domain.lecture.repository.custom.CustomRegisteredLectureRepository
 import team.msg.domain.student.model.QStudent.student
 import team.msg.domain.student.model.Student
@@ -72,4 +73,13 @@ class CustomRegisteredLectureRepositoryImpl(
             )
             .fetch()
 
+    override fun findByLectureIdAndStudentId(lectureId: UUID,studentId: UUID): RegisteredLecture? =
+        queryFactory.selectFrom(registeredLecture)
+            .leftJoin(registeredLecture.lecture, lecture)
+            .leftJoin(registeredLecture.student, student)
+            .where(
+                lecture.id.eq(lectureId),
+                student.id.eq(studentId)
+            )
+            .fetchOne()
 }


### PR DESCRIPTION
## 💡 배경 및 개요

강의 이수 여부를 수정하는 api를 작성했습니다.

Resolves: #386 

## 📃 작업내용

- 강의에 신청한 학생들의 강의 이수 여부를 변경하는 api입니다.
- 권한 별로 이수 여부를 수정할 수 있는 학생의 범위를 다르게 하였습니다.
  - 어드민 -> 모든 학생
  - 뽀짝, 취동쌤 -> 소속 동아리 학생
  - 강사 -> 자신이 강의하는 강의를 신청한 학생들만 (다른 강의 학생의 이수 여부를 변경할 시 예외)

## 🙋‍♂️ 리뷰노트

감사합니다

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
