### PR TITLE
비밀번호를 변경한 후 인증을 초기화하도록 로직을 추가했습니다.

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -290,6 +290,8 @@ class AuthServiceImpl(
         if(!emailAuthentication.isAuthentication)
             throw UnAuthenticatedEmailException("아직 인증되지 않은 이메일입니다. info : [ email = ${changePasswordRequest.email} ]")
 
+        emailAuthenticationRepository.delete(emailAuthentication)
+
         val encodedNewPassword = securityUtil.passwordEncode(changePasswordRequest.newPassword)
 
         val modifiedPasswordUser = User(

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/email/service/EmailServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/email/service/EmailServiceImpl.kt
@@ -16,12 +16,15 @@ import team.msg.domain.email.model.EmailAuthentication
 import team.msg.domain.email.presentation.data.request.SendAuthenticationEmailRequest
 import team.msg.domain.email.presentation.data.response.CheckEmailAuthenticationResponse
 import team.msg.domain.email.repository.EmailAuthenticationRepository
+import team.msg.domain.user.exception.UserNotFoundException
+import team.msg.domain.user.repository.UserRepository
 import team.msg.global.config.properties.EmailProperties
 import java.util.*
 
 @Service
 class EmailServiceImpl(
     private val emailAuthenticationRepository: EmailAuthenticationRepository,
+    private val userRepository: UserRepository,
     private val templateEngine: SpringTemplateEngine,
     private val mailSender: JavaMailSender,
     private val emailProperties: EmailProperties
@@ -33,6 +36,10 @@ class EmailServiceImpl(
     @Transactional(rollbackFor = [Exception::class])
     override fun sendAuthenticationEmail(request: SendAuthenticationEmailRequest) {
         val email = request.email
+
+        if(!userRepository.existsByEmail(email))
+            throw UserNotFoundException("이메일로 가입된 유저를 찾을 수 없습니다. info : [ email = $email ]")
+
         val code = UUID.randomUUID().toString()
 
         val emailAuthentication = emailAuthenticationRepository.findByIdOrNull(email)

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/auth/service/AuthServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/auth/service/AuthServiceImplTest.kt
@@ -692,8 +692,9 @@ class AuthServiceImplTest : BehaviorSpec({
             property(EmailAuthentication::isAuthentication) { true }
         }
 
-        every { userRepository.findByEmail(any()) } returns user
-        every { emailAuthenticationRepository.findByIdOrNull(any()) } returns emailAuthentication
+        every { userRepository.findByEmail(email) } returns user
+        every { emailAuthenticationRepository.findByIdOrNull(email) } returns emailAuthentication
+        every { emailAuthenticationRepository.delete(emailAuthentication) } returns Unit
         every { securityUtil.passwordEncode(any()) } returns encodedNewPassword
         every { userRepository.save(any()) } returns modifiedPasswordUser
 
@@ -702,6 +703,10 @@ class AuthServiceImplTest : BehaviorSpec({
 
             Then("유저가 저장되어야 한다.") {
                 verify(exactly = 1) { userRepository.save(any()) }
+            }
+
+            Then("인증이 초기화되어야 한다.") {
+                verify(exactly = 1) { emailAuthenticationRepository.delete(emailAuthentication) }
             }
         }
 


### PR DESCRIPTION
## 💡 배경 및 개요

비밀번호를 변경한 후 일정 시간동안 인증이 남아있는 것을 확인했습니다. 비밀번호를 변경하면 인증을 초기화하도록 로직을 추가했습니다.

Resolves: #340 

## 📃 작업내용

- 비밀번호 변경 시 emailAuthentication을 삭제
- 위 테스트 코드 추가
- 가입하지 않은 유저는 이메일 인증 메일을 보내지 않도록 예외 추가

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?
