### PR TITLE
🔀 :: ec2 내부 build 로직 삭제

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -3,7 +3,7 @@ os: linux
 
 files:
   - source: /
-    destination: /home/ec2-user/action/
+    destination: /home/ec2-user/Bitgouel-Server/
     overwrite: yes
 
 permissions:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,12 +4,6 @@ JAR_PATH=$REPOSITORY/$PROJECT_NAME/bitgouel-api/build/libs/bitgouel-api-0.0.1-SN
 
 cd $REPOSITORY/$PROJECT_NAME/
 
-echo "> Git Pull"
-git pull origin master
-
-echo "> Project Build"
-./gradlew clean bitgouel-api:build
-
 CURRENT_PID=$(lsof -i tcp:8080)
 if [ -z "$CURRENT_PID" ]; then
     echo "> 현재 구동중인 애플리케이션이 없으므로 종료하지 않습니다."


### PR DESCRIPTION
## 💡 배경 및 개요

ec2 내에서 build 작업 수행 시 ec2 인스턴스가 멈추는 문제가 발생하였습니다

Resolves: #408

## 📃 작업내용

appspec.yml에서 s3의 빌드된 프로젝트를 복사하는 경로를 기존의 /home/ec2-user/action에서 /home/ec2-user/Bitgouel-Server로 변경했습니다

codedeploy가 실행시키는 쉘 스크립트인 deploy.sh에서 추가적인 build 작업을 삭제했습니다

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
