### PR TITLE
# 414 Jar 파일 실행 시 타임 존 설정

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,4 +16,4 @@ fi
 echo "> 애플리케이션 배포"
 JAR_NAME=$(ls -tr $JAR_PATH | tail -n 1)
 echo "> JAR NAME: $JAR_NAME"
-nohup java -jar $JAR_NAME  --logging.file.path=/home/ec2-user/ --logging.level.org.hibernate.SQL=DEBUG >> /home/ec2-user/deploy.log 2>/home/ec2-user/deploy_err.log &
+TZ='Asia/Seoul' nohup java -jar $JAR_NAME --logging.file.path=/home/ec2-user/ --logging.level.org.hibernate.SQL=DEBUG >> /home/ec2-user/deploy.log 2>/home/ec2-user/deploy_err.log &


### PR DESCRIPTION
## 💡 배경 및 개요

Jar 파일 실행 시 타임 존 설정

Resolves: #{414}

## 📃 작업내용

배포 환경에서 시간이 맞지 않는 문제를 해결하기 위해 타임 존 설정을 해주었습니다.