### PR TITLE
# 422 전체적인 컨벤션 제어 및 사용하지 않는 코드 삭제

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,26 +7,26 @@
 
 ## ERD
 
-![](./assets/img/bitgoeul_erd.png)
+![Erd](./assets/img/bitgoeul_erd.png)
 
 ---
 
 ## Class Diagram
 
-![](./assets/img/project_diagram.png)
+![class-diagram](./assets/img/project_diagram.png)
 
 --- 
 
 ## Commit Message Rule
 
-type | meaning |
---|--
-create | 새로운 클래스를 생성했을 때
-add | 새로운 기능(메서드를) 추가했을 때
-update | 변경사항을 적용했을 때
-refactor | 코드를 개선했을 때
-fix | 버그, 이슈를 해결했을 때
-delete | 삭제한 사항이 생겼을 때
-chore | 귀찮은 일 해냈을 때
-docs | 문서화 작업을 진행했을 때
-test | 테스트 관련 사항이 있을 때
+| type     | meaning             |
+|----------|---------------------|
+| create   | 새로운 클래스를 생성했을 때     |
+| add      | 새로운 기능(메서드를) 추가했을 때 |
+| update   | 변경사항을 적용했을 때        |
+| refactor | 코드를 개선했을 때          |
+| fix      | 버그, 이슈를 해결했을 때      |
+| delete   | 삭제한 사항이 생겼을 때       |
+| chore    | 귀찮은 일 해냈을 때         |
+| docs     | 문서화 작업을 진행했을 때      |
+| test     | 테스트 관련 사항이 있을 때     |

--- a/bitgouel-api/src/main/kotlin/team/msg/BitgouelApplication.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/BitgouelApplication.kt
@@ -9,4 +9,3 @@ class BitgouelApplication
 fun main(args: Array<String>) {
     runApplication<BitgouelApplication>(*args)
 }
-

--- a/bitgouel-api/src/main/kotlin/team/msg/common/aop/log/HttpLoggingAspect.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/common/aop/log/HttpLoggingAspect.kt
@@ -73,7 +73,7 @@ class HttpLoggingAspect {
         return result
     }
 
-    private fun params(joinPoint: JoinPoint): Map<*,*>? {
+    private fun params(joinPoint: JoinPoint): Map<*,*> {
         val codeSignature = joinPoint.signature as CodeSignature
         val parameterNames = codeSignature.parameterNames
         val args = joinPoint.args

--- a/bitgouel-api/src/main/kotlin/team/msg/common/aop/log/HttpLoggingAspect.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/common/aop/log/HttpLoggingAspect.kt
@@ -12,9 +12,8 @@ import org.springframework.stereotype.Component
 import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.context.request.ServletRequestAttributes
 import team.msg.common.logger.LoggerDelegator
+import team.msg.global.exception.InternalServerException
 import java.util.*
-import kotlin.collections.HashMap
-import kotlin.collections.HashSet
 
 @Aspect
 @Component
@@ -68,7 +67,7 @@ class HttpLoggingAspect {
             }
 
             else -> {
-                throw RuntimeException("유효하지 않은 Controller 반환 타입입니다.")
+                throw InternalServerException("유효하지 않은 Controller 반환 타입입니다.")
             }
         }
         return result

--- a/bitgouel-api/src/main/kotlin/team/msg/common/init/DataInitializer.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/common/init/DataInitializer.kt
@@ -90,6 +90,7 @@ class DataInitializer(
             Club(7, gwangjuTechnicalHighSchool, "전자 히어로즈"),
             Club(8, gwangjuTechnicalHighSchool, "Civil 마스터"),
             Club(9, gwangjuTechnicalHighSchool, "건축연구소"),
+
             /**
             * Kumpa Technical HighSchool's Club
             * Kumpa Technical HighSchool ID = 2
@@ -101,6 +102,7 @@ class DataInitializer(
             Club(14, kumpaTechnicalHighSchool, "어썸"),
             Club(15, kumpaTechnicalHighSchool, "다이나믹"),
             Club(16, kumpaTechnicalHighSchool, "금호로80 베이커리"),
+
             /**
              * Jeonnam Technical HighSchool's Club
              * Jeonnam Technical HighSchool ID = 3
@@ -111,6 +113,7 @@ class DataInitializer(
             Club(20, jeonnamTechnicalHighSchool, "라온하제"),
             Club(21, jeonnamTechnicalHighSchool, "스카이드론"),
             Club(22, jeonnamTechnicalHighSchool, "그린라이트"),
+
             /**
              * Gwangju Girls Commercial HighSchool's Club
              * Gwangju Girls Commercial HighSchool ID = 4
@@ -118,10 +121,12 @@ class DataInitializer(
             Club(23, gwangjuGirlsCommercialHighSchool, "금융실무"),
             Club(24, gwangjuGirlsCommercialHighSchool, "소개팅"),
             Club(25, gwangjuGirlsCommercialHighSchool, "취사모"),
+
             /**
              * Jeonnam Girls Commercial HighSchool's Club
              * Jeonnam Girls Commercial HighSchool ID = 5
              */
+
             /**
              * Gwangju Natural Science HighSchool's Club
              * Gwangju Natural Science HighSchool ID = 6
@@ -130,6 +135,7 @@ class DataInitializer(
             Club(27, gwangjuNaturalScienceHighSchool, "뉴쿡"),
             Club(28, gwangjuNaturalScienceHighSchool, "베이커리 카페 CEO"),
             Club(29, gwangjuNaturalScienceHighSchool, "우아행"),
+
             /**
              * Gwangju Electronic Technical HighSchool's Club
              * Gwangju Electronic Technical HighSchool ID = 7
@@ -141,6 +147,7 @@ class DataInitializer(
             Club(34, gwangjuElectronicTechnicalHighSchool, "Tesla"),
             Club(35, gwangjuElectronicTechnicalHighSchool, "발자국"),
             Club(36, gwangjuElectronicTechnicalHighSchool, "M lab"),
+
             /**
              * Dongil HighSchool Of Future Science HighSchool's Club
              * Dongil HighSchool Of Future Science HighSchool ID = 8
@@ -154,6 +161,7 @@ class DataInitializer(
              * Seojin Girls HighSchool's Club
              * Seojin Girls HighSchool ID = 9
              */
+
             /**
              * Sungui Science Technology HighSchool's Club
              * Sungui Science Technology HighSchool ID = 10
@@ -168,6 +176,7 @@ class DataInitializer(
             Club(49, sunguiScienceTechnologyHighSchool, "내빵네빵"),
             Club(50, sunguiScienceTechnologyHighSchool, "카페바리"),
             Club(51, sunguiScienceTechnologyHighSchool, "쿠킹마스터즈"),
+
             /**
              * Songwon Girls Commercial HighSchool's Club
              * Songwon Girls Commercial HighSchool ID = 11
@@ -176,6 +185,7 @@ class DataInitializer(
             Club(53, songwonGirlsCommercialHighSchool, "미용서비스"),
             Club(54, songwonGirlsCommercialHighSchool, "뷰티아트"),
             Club(55, songwonGirlsCommercialHighSchool, "클로즈업"),
+
             /**
              * Gwangju Automatic Equipment Technical HighSchool's Club
              * Gwangju Automatic Equipment Technical HighSchool ID = 12

--- a/bitgouel-api/src/main/kotlin/team/msg/common/init/DataInitializer.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/common/init/DataInitializer.kt
@@ -43,7 +43,7 @@ class DataInitializer(
      * school, club id = 1인 엔티티가 존재하면 Data Init을 실행하지 않는다.
      */
     @EventListener(ApplicationReadyEvent::class)
-    @Transactional
+    @Transactional(readOnly = true)
     fun initData() {
         if(!schoolRepository.existsOne(1)) {
             log.info("=== RUN Init School Data ===")

--- a/bitgouel-api/src/main/kotlin/team/msg/common/util/StudentUtil.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/common/util/StudentUtil.kt
@@ -12,6 +12,7 @@ import java.util.*
 class StudentUtil(
     private val studentRepository: StudentRepository
 ) {
+
     fun createStudent(user: User, club: Club, grade: Int, classRoom: Int, number: Int, admissionNumber: Int) {
         val student = Student(
             id = UUID.randomUUID(),

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/presentation/AdminController.kt
@@ -1,6 +1,5 @@
 package team.msg.domain.admin.presentation
 
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
@@ -44,6 +43,6 @@ class AdminController(
     @PostMapping("/excel")
     fun uploadStudentListExcel(@RequestPart file: MultipartFile): ResponseEntity<Void> {
         adminService.uploadStudentListExcel(file)
-        return ResponseEntity.status(HttpStatus.OK).build()
+        return ResponseEntity.ok().build()
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -35,6 +35,7 @@ class AdminServiceImpl(
      * @param 유저를 검색할 조건으로 keyword, authority, approveStatus
      * @return 학생 정보를 리스트로 담은 Dto
      */
+    @Transactional(readOnly = true)
     override fun queryUsers(request: QueryUsersRequest): UsersResponse {
         val users = userRepository.query(request.keyword, request.authority, request.approveStatus)
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -30,6 +30,7 @@ class AdminServiceImpl(
     private val studentUtil: StudentUtil,
     private val clubRepository: ClubRepository
 ) : AdminService {
+
     /**
      * 유저를 전체 조회 및 이름, 역할, 승인 상태들로 조회하는 비즈니스 로직입니다
      * @param 유저를 검색할 조건으로 keyword, authority, approveStatus

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/exception/InvalidRefreshTokenException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/exception/InvalidRefreshTokenException.kt
@@ -5,5 +5,4 @@ import team.msg.global.error.exception.BitgouelException
 
 class InvalidRefreshTokenException(
     message: String
-) : BitgouelException(message, AuthErrorCode.INVALID_TOKEN.status){
-}
+) : BitgouelException(message, AuthErrorCode.INVALID_TOKEN.status)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/AuthController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/AuthController.kt
@@ -80,12 +80,12 @@ class AuthController(
     @DeleteMapping
     fun logout(@RequestHeader("RefreshToken") refreshToken: String): ResponseEntity<Void> {
         authService.logout(refreshToken)
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+        return ResponseEntity.noContent().build()
     }
 
     @DeleteMapping("/withdraw")
     fun withdraw(): ResponseEntity<Void> {
         authService.withdraw()
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+        return ResponseEntity.noContent().build()
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/AuthController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/AuthController.kt
@@ -1,6 +1,5 @@
 package team.msg.domain.auth.presentation
 
-import javax.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -8,6 +7,7 @@ import team.msg.domain.auth.mapper.AuthRequestMapper
 import team.msg.domain.auth.presentation.data.response.TokenResponse
 import team.msg.domain.auth.presentation.data.web.*
 import team.msg.domain.auth.service.AuthService
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/auth")

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/AuthController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/presentation/AuthController.kt
@@ -1,5 +1,6 @@
 package team.msg.domain.auth.presentation
 
+import javax.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -7,7 +8,6 @@ import team.msg.domain.auth.mapper.AuthRequestMapper
 import team.msg.domain.auth.presentation.data.response.TokenResponse
 import team.msg.domain.auth.presentation.data.web.*
 import team.msg.domain.auth.service.AuthService
-import javax.validation.Valid
 
 @RestController
 @RequestMapping("/auth")

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthService.kt
@@ -11,15 +11,15 @@ import team.msg.domain.auth.presentation.data.request.TeacherSignUpRequest
 import team.msg.domain.auth.presentation.data.response.TokenResponse
 
 interface AuthService {
-    fun studentSignUp(studentSignUpRequest: StudentSignUpRequest)
-    fun teacherSignUp(teacherSignUpRequest: TeacherSignUpRequest)
-    fun bbozzakSignUp(bbozzakSignUpRequest: BbozzakSignUpRequest)
-    fun professorSignUp(professorSignUpRequest: ProfessorSignUpRequest)
-    fun governmentSignUp(governmentSignUpRequest: GovernmentSignUpRequest)
-    fun companyInstructorSignUp(companyInstructorSignUpRequest: CompanyInstructorSignUpRequest)
+    fun studentSignUp(request: StudentSignUpRequest)
+    fun teacherSignUp(request: TeacherSignUpRequest)
+    fun bbozzakSignUp(request: BbozzakSignUpRequest)
+    fun professorSignUp(request: ProfessorSignUpRequest)
+    fun governmentSignUp(request: GovernmentSignUpRequest)
+    fun companyInstructorSignUp(request: CompanyInstructorSignUpRequest)
     fun login(request: LoginRequest): TokenResponse
-    fun reissueToken(refreshToken: String): TokenResponse
-    fun logout(refreshToken: String)
-    fun changePassword(changePasswordRequest: ChangePasswordRequest)
+    fun reissueToken(requestToken: String): TokenResponse
+    fun logout(requestToken: String)
+    fun changePassword(request: ChangePasswordRequest)
     fun withdraw()
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.msg.common.enums.ApproveStatus
 import team.msg.common.util.SecurityUtil
+import team.msg.common.util.StudentUtil
 import team.msg.common.util.UserUtil
 import team.msg.domain.auth.exception.*
 import team.msg.domain.auth.presentation.data.request.*
@@ -28,8 +29,6 @@ import team.msg.domain.professor.repository.ProfessorRepository
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.school.exception.SchoolNotFoundException
 import team.msg.domain.school.repository.SchoolRepository
-import team.msg.domain.student.enums.StudentRole
-import team.msg.domain.student.model.Student
 import team.msg.domain.student.repository.StudentRepository
 import team.msg.domain.teacher.model.Teacher
 import team.msg.domain.teacher.repository.TeacherRepository
@@ -59,7 +58,8 @@ class AuthServiceImpl(
     private val emailAuthenticationRepository: EmailAuthenticationRepository,
     private val userUtil: UserUtil,
     private val applicationEventPublisher: ApplicationEventPublisher,
-    private val bbozzakRepository: BbozzakRepository
+    private val bbozzakRepository: BbozzakRepository,
+    private val studentUtil: StudentUtil
 ) : AuthService {
 
     /**
@@ -78,18 +78,7 @@ class AuthServiceImpl(
 
         val club = queryClub(request.highSchool, request.clubName)
 
-        val student = Student(
-            id = UUID.randomUUID(),
-            user = user,
-            club = club,
-            grade = request.grade,
-            classRoom = request.classRoom,
-            number = request.number,
-            cohort = request.admissionNumber - 2020,
-            credit = 0,
-            studentRole = StudentRole.STUDENT
-        )
-        studentRepository.save(student)
+        studentUtil.createStudent(user, club, request.grade, request.classRoom, request.number, request.admissionNumber)
     }
 
     /**

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -222,7 +222,7 @@ class AuthServiceImpl(
      * 로그인을 처리하는 비지니스 로직입니다.
      * @param 로그인을 처리하기 위한 request dto 입니다.
      */
-    @Transactional(rollbackFor = [Exception::class], readOnly = true)
+    @Transactional(rollbackFor = [Exception::class])
     override fun login(request: LoginRequest): TokenResponse {
         val user = userRepository.findByEmail(request.email)
             ?: throw UserNotFoundException("존재하지 않는 유저입니다.")
@@ -240,7 +240,7 @@ class AuthServiceImpl(
      * 토큰 재발급을 처리하는 메서드입니다.
      * @param 토큰 재발급을 처리하기 위한 refreshToken 입니다.
      */
-    @Transactional(rollbackFor = [Exception::class], readOnly = true)
+    @Transactional(rollbackFor = [Exception::class])
     override fun reissueToken(requestToken: String): TokenResponse {
         val refreshToken = jwtTokenParser.parseRefreshToken(requestToken)
             ?: throw InvalidRefreshTokenException("유효하지 않은 리프레시 토큰입니다. info : [ refreshToken = $requestToken ]")

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/CertificationController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/CertificationController.kt
@@ -1,5 +1,6 @@
 package team.msg.domain.certification.presentation
 
+import javax.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -9,7 +10,6 @@ import team.msg.domain.certification.presentation.data.web.CreateCertificationWe
 import team.msg.domain.certification.presentation.data.web.UpdateCertificationWebRequest
 import team.msg.domain.certification.service.CertificationService
 import java.util.*
-import javax.validation.Valid
 
 @RestController
 @RequestMapping("/certification")

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/CertificationController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/presentation/CertificationController.kt
@@ -27,19 +27,19 @@ class CertificationController(
     @GetMapping
     fun queryCertifications(): ResponseEntity<CertificationsResponse> {
         val response = certificationService.queryCertifications()
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/{student_id}")
     fun queryCertifications(@PathVariable("student_id") studentId: UUID): ResponseEntity<CertificationsResponse> {
         val response = certificationService.queryCertifications(studentId)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @PatchMapping("/{id}")
     fun updateCertification(@PathVariable id: UUID, @RequestBody @Valid webRequest: UpdateCertificationWebRequest): ResponseEntity<Void> {
         val request = certificationRequestMapper.updateCertificationWebRequestToDto(webRequest)
         certificationService.updateCertification(id, request)
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+        return ResponseEntity.noContent().build()
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationService.kt
@@ -6,8 +6,8 @@ import team.msg.domain.certification.presentation.data.response.CertificationsRe
 import java.util.UUID
 
 interface CertificationService {
-    fun createCertification(createCertificationRequest: CreateCertificationRequest)
+    fun createCertification(request: CreateCertificationRequest)
     fun queryCertifications(): CertificationsResponse
     fun queryCertifications(studentId: UUID): CertificationsResponse
-    fun updateCertification(id: UUID, updateCertificationRequest: UpdateCertificationRequest)
+    fun updateCertification(id: UUID,request: UpdateCertificationRequest)
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
@@ -97,12 +97,12 @@ class CertificationServiceImpl(
         val entity = userUtil.getAuthorityEntityAndOrganization(user).first
 
         val club = when(entity) {
-            is Student -> findStudentByUser(user).club
-            is Teacher -> findTeacherByUser(user).club
-            is Bbozzak -> findBbozzakByUser(user).club
-            is Professor -> findProfessorByUser(user).club
-            is CompanyInstructor -> findCompanyInstructorByUser(user).club
-            is Government -> findGovernmentByUser(user).club
+            is Student -> (studentRepository findStudentByUser user).club
+            is Teacher -> (teacherRepository findTeacherByUser user).club
+            is Bbozzak -> (bbozzakRepository findBbozzakByUser user).club
+            is Professor -> (professorRepository findProfessorByUser user).club
+            is CompanyInstructor -> (companyInstructorRepository findCompanyInstructorByUser  user).club
+            is Government -> (governmentRepository findGovernmentByUser user).club
             is Admin -> null
             else ->  throw InvalidRoleException("유효하지 않은 권한입니다. info : [ userAuthority = ${user.authority} ]")
         }
@@ -160,25 +160,28 @@ class CertificationServiceImpl(
         this.findByIdOrNull(id)
             ?: throw CertificationNotFoundException("존재하지 않는 자격증입니다. info : [ certificationId = $id ]")
 
-    private infix fun TeacherRepository.findByUser(user: User): Teacher =
+    private infix fun StudentRepository.findStudentByUser(user: User): Student =
         this.findByUser(user)
-            ?: throw TeacherNotFoundException("존재하지 않는 선생님입니다. info : [ userId = ${user.id} ]")
+            ?: throw StudentNotFoundException("학생을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
 
-    private fun findStudentByUser(user: User) = studentRepository.findByUser(user)
-        ?: throw StudentNotFoundException("학생을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+    private infix fun TeacherRepository.findTeacherByUser(user: User): Teacher =
+        this.findByUser(user)
+            ?: throw TeacherNotFoundException("취업 동아리 선생님을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
 
-    private fun findTeacherByUser(user: User) = teacherRepository.findByUser(user)
-        ?: throw TeacherNotFoundException("취업 동아리 선생님을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+    private infix fun BbozzakRepository.findBbozzakByUser(user: User): Bbozzak =
+        this.findByUser(user)
+            ?: throw BbozzakNotFoundException("뽀짝 선생님을 찾을 수 없습니다.  info : [ userId = ${user.id} ]")
 
-    private fun findBbozzakByUser(user: User) = bbozzakRepository.findByUser(user)
-        ?: throw BbozzakNotFoundException("뽀짝 선생님을 찾을 수 없습니다.  info : [ userId = ${user.id} ]")
+    private infix fun ProfessorRepository.findProfessorByUser(user: User): Professor =
+        this.findByUser(user)
+            ?: throw ProfessorNotFoundException("대학 교수를 찾을 수 없습니다. info : [ userId = ${user.id} ]")
 
-    private fun findProfessorByUser(user: User) = professorRepository.findByUser(user)
-        ?: throw ProfessorNotFoundException("대학 교수를 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+    private infix fun CompanyInstructorRepository.findCompanyInstructorByUser(user: User): CompanyInstructor =
+        this.findByUser(user)
+            ?: throw CompanyNotFoundException("기업 강사를 찾을 수 없습니다. info : [ userId = ${user.id} ]")
 
-    private fun findCompanyInstructorByUser(user: User) = companyInstructorRepository.findByUser(user)
-        ?: throw CompanyNotFoundException("기업 강사를 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+    private infix fun GovernmentRepository.findGovernmentByUser(user: User): Government =
+        this.findByUser(user)
+            ?: throw GovernmentNotFoundException("유관기관을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
 
-    private fun findGovernmentByUser(user: User) = governmentRepository.findByUser(user)
-        ?: throw GovernmentNotFoundException("유관기관을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
@@ -101,7 +101,7 @@ class CertificationServiceImpl(
             is Teacher -> (teacherRepository findTeacherByUser user).club
             is Bbozzak -> (bbozzakRepository findBbozzakByUser user).club
             is Professor -> (professorRepository findProfessorByUser user).club
-            is CompanyInstructor -> (companyInstructorRepository findCompanyInstructorByUser  user).club
+            is CompanyInstructor -> (companyInstructorRepository findCompanyInstructorByUser user).club
             is Government -> (governmentRepository findGovernmentByUser user).club
             is Admin -> null
             else ->  throw InvalidRoleException("유효하지 않은 권한입니다. info : [ userAuthority = ${user.authority} ]")

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
@@ -1,6 +1,5 @@
 package team.msg.domain.club.presentation
 
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import team.msg.domain.club.presentation.data.response.ClubDetailsResponse

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/club/presentation/ClubController.kt
@@ -18,24 +18,24 @@ class ClubController(
     @GetMapping
     fun queryAllClubs(@RequestParam("highSchool") highSchool: HighSchool): ResponseEntity<ClubsResponse> {
         val response = clubService.queryAllClubs(highSchool)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/{id}")
     fun queryClubDetails(@PathVariable id: Long): ResponseEntity<ClubDetailsResponse> {
         val response = clubService.queryClubDetailsById(id)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/my")
     fun queryMyClubDetails(): ResponseEntity<ClubDetailsResponse> {
         val response = clubService.queryMyClubDetails()
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/{id}/{student_id}")
     fun queryStudentDetails(@PathVariable("id") clubId: Long, @PathVariable("student_id") studentId: UUID): ResponseEntity<StudentDetailsResponse> {
         val response = clubService.queryStudentDetails(clubId, studentId)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/email/presentation/data/response/CheckEmailAuthenticationResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/email/presentation/data/response/CheckEmailAuthenticationResponse.kt
@@ -1,5 +1,5 @@
 package team.msg.domain.email.presentation.data.response
 
-data class CheckEmailAuthenticationResponse (
+data class CheckEmailAuthenticationResponse(
     val isAuthentication: Boolean
 )

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/email/service/EmailServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/email/service/EmailServiceImpl.kt
@@ -29,6 +29,7 @@ class EmailServiceImpl(
     private val mailSender: JavaMailSender,
     private val emailProperties: EmailProperties
 ) : EmailService {
+
     /**
      * 입력된 email로 인증 링크를 전송하는 비지니스 로직입니다.
      * @param 인증 링크가 전송될 email이 담긴 dto

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/faq/exception/FaqNotFoundException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/faq/exception/FaqNotFoundException.kt
@@ -1,8 +1,0 @@
-package team.msg.domain.faq.exception
-
-import team.msg.domain.faq.exception.constant.FaqErrorCode
-import team.msg.global.error.exception.BitgouelException
-
-class FaqNotFoundException(
-    message: String
-) : BitgouelException(message, FaqErrorCode.FAQ_NOT_FOUND.status)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/faq/exception/constant/FaqErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/faq/exception/constant/FaqErrorCode.kt
@@ -1,7 +1,0 @@
-package team.msg.domain.faq.exception.constant
-
-enum class FaqErrorCode(
-    val status: Int
-) {
-    FAQ_NOT_FOUND(404)
-}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/faq/mapper/FaqRequestMapper.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/faq/mapper/FaqRequestMapper.kt
@@ -4,5 +4,5 @@ import team.msg.domain.faq.presentation.data.request.CreateFaqRequest
 import team.msg.domain.faq.presentation.web.CreateFaqWebRequest
 
 interface FaqRequestMapper {
-    fun createFaqWebRequestToDto(createFaqWebRequest: CreateFaqWebRequest): CreateFaqRequest
+    fun createFaqWebRequestToDto(webRequest: CreateFaqWebRequest): CreateFaqRequest
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/faq/mapper/FaqRequestMapperImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/faq/mapper/FaqRequestMapperImpl.kt
@@ -10,10 +10,10 @@ class FaqRequestMapperImpl : FaqRequestMapper {
     /**
      * FAQ 등록 Web Request 를 애플리케이션 영역에서 사용될 Dto 로 매핑합니다.
      */
-    override fun createFaqWebRequestToDto(createFaqWebRequest: CreateFaqWebRequest): CreateFaqRequest =
+    override fun createFaqWebRequestToDto(webRequest: CreateFaqWebRequest): CreateFaqRequest =
         CreateFaqRequest(
-            question = createFaqWebRequest.question,
-            answer = createFaqWebRequest.answer
+            question = webRequest.question,
+            answer = webRequest.answer
         )
 
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/faq/service/FAQServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/faq/service/FAQServiceImpl.kt
@@ -11,7 +11,6 @@ import team.msg.domain.faq.presentation.data.response.FaqResponse
 import team.msg.domain.faq.presentation.data.response.FaqsResponse
 import team.msg.domain.faq.repository.FaqRepository
 
-
 @Service
 class FaqServiceImpl(
     private val faqRepository: FaqRepository,
@@ -28,7 +27,7 @@ class FaqServiceImpl(
         val user = userUtil.queryCurrentUser()
 
         val admin = adminRepository.findByUser(user)
-            ?: throw AdminNotFoundException("어드민을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
+            ?: throw AdminNotFoundException("존재하지 않는 어드민입니다. info : [ userId = ${user.id} ]")
 
         val faq = Faq(
             question = createFaqRequest.question,

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/health/HealthCheckController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/health/HealthCheckController.kt
@@ -11,6 +11,6 @@ class HealthCheckController(
 ) {
 
     @GetMapping
-    fun healthCheck() = ResponseEntity.ok("Bitgouel Server is OK, PORT = ${env.getProperty("server.port")}")
+    fun healthCheck(): ResponseEntity<String> = ResponseEntity.ok("Bitgouel Server is OK, PORT = ${env.getProperty("server.port")}")
 
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/InquiryController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/InquiryController.kt
@@ -74,7 +74,7 @@ class InquiryController(
     }
 
     @PostMapping("/{id}/answer")
-    fun replyInquiry(@PathVariable id: UUID , @Valid @RequestBody webRequest: CreateInquiryAnswerWebRequest): ResponseEntity<Void> {
+    fun replyInquiry(@PathVariable id: UUID, @Valid @RequestBody webRequest: CreateInquiryAnswerWebRequest): ResponseEntity<Void> {
         val request = inquiryMapper.createInquiryAnswerWebRequestToDto(webRequest)
         inquiryService.replyInquiry(id, request)
         return ResponseEntity.noContent().build()

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/exception/InvalidLectureTypeException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/exception/InvalidLectureTypeException.kt
@@ -1,8 +1,0 @@
-package team.msg.domain.lecture.exception
-
-import team.msg.domain.lecture.exception.constant.LectureErrorCode
-import team.msg.global.error.exception.BitgouelException
-
-class InvalidLectureTypeException(
-    message: String
-) : BitgouelException(message, LectureErrorCode.INVALID_LECTURE_TYPE.status)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/exception/RegisteredLectureCountNotFoundException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/exception/RegisteredLectureCountNotFoundException.kt
@@ -1,9 +1,0 @@
-package team.msg.domain.lecture.exception
-
-import team.msg.domain.lecture.exception.constant.LectureErrorCode
-import team.msg.global.error.exception.BitgouelException
-
-class RegisteredLectureCountNotFoundException(
-    message: String
-) : BitgouelException(message, LectureErrorCode.REGISTERED_LECTURE_COUNT_NOT_FOUND.status) {
-}

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/exception/UnApprovedLectureException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/exception/UnApprovedLectureException.kt
@@ -1,8 +1,0 @@
-package team.msg.domain.lecture.exception
-
-import team.msg.domain.lecture.exception.constant.LectureErrorCode
-import team.msg.global.error.exception.BitgouelException
-
-class UnApprovedLectureException(
-    message: String
-) : BitgouelException(message, LectureErrorCode.UNAPPROVED_LECTURE.status)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/exception/constant/LectureErrorCode.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/exception/constant/LectureErrorCode.kt
@@ -3,13 +3,8 @@ package team.msg.domain.lecture.exception.constant
 enum class LectureErrorCode(
     val status: Int
 ){
-    INVALID_LECTURE_TYPE(400),
-
     FORBIDDEN_SIGNED_UP_LECTURE(403),
-
     LECTURE_NOT_FOUND(404),
-    REGISTERED_LECTURE_COUNT_NOT_FOUND(404),
-
     ALREADY_APPROVED_LECTURE(409),
     ALREADY_SIGNED_UP_LECTURE(409),
     UNAPPROVED_LECTURE(409),

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
@@ -54,64 +54,64 @@ class LectureController(
     @PostMapping("/{id}")
     fun signUpLecture(@PathVariable id: UUID): ResponseEntity<Void> {
         lectureService.signUpLecture(id)
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+        return ResponseEntity.noContent().build()
     }
 
     @DeleteMapping("/{id}")
     fun cancelSignUpLecture(@PathVariable id: UUID): ResponseEntity<Void> {
         lectureService.cancelSignUpLecture(id)
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+        return ResponseEntity.noContent().build()
     }
 
     @GetMapping("/{id}")
     fun queryLectureDetails(@PathVariable id: UUID): ResponseEntity<LectureDetailsResponse> {
         val response = lectureService.queryLectureDetails(id)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/instructor")
     fun queryInstructors(@RequestParam keyword: String): ResponseEntity<InstructorsResponse> {
         val response = lectureService.queryInstructors(keyword)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/line")
     fun queryAllLines(webRequest: QueryAllLinesWebRequest): ResponseEntity<LinesResponse> {
         val request = lectureRequestMapper.queryAllLinesWebRequestToDto(webRequest)
         val response = lectureService.queryAllLines(request)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/department")
     fun queryAllDepartments(webRequest: QueryAllDepartmentsWebRequest): ResponseEntity<DepartmentsResponse> {
         val request = lectureRequestMapper.queryAllDepartmentsWebRequestToDto(webRequest)
         val response = lectureService.queryAllDepartments(request)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/division")
     fun queryAllDivisions(webRequest: QueryAllDivisionsWebRequest): ResponseEntity<DivisionsResponse> {
         val request = lectureRequestMapper.queryAllDivisionsWebRequestToDto(webRequest)
         val response = lectureService.queryAllDivisions(request)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/excel")
     fun lectureReceiptStatusExcel(response: HttpServletResponse): ResponseEntity<Void> {
         lectureService.lectureReceiptStatusExcel(response)
-        return ResponseEntity.status(HttpStatus.OK).build()
+        return ResponseEntity.ok().build()
     }
 
     @GetMapping("/{student_id}/signup")
     fun queryAllSignedUpLectures(@PathVariable("student_id") studentId: UUID): ResponseEntity<SignedUpLecturesResponse> {
         val response = lectureService.queryAllSignedUpLectures(studentId)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/student/{id}")
     fun queryAllSignedUpStudents(@PathVariable id: UUID): ResponseEntity<SignedUpStudentsResponse> {
         val response = lectureService.queryAllSignedUpStudents(id)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @PatchMapping("/{id}/{student_id}")
@@ -120,6 +120,6 @@ class LectureController(
         @RequestParam isComplete: Boolean
     ): ResponseEntity<Unit> {
         val response = lectureService.updateLectureCompleteStatus(id, studentId, isComplete)
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+        return ResponseEntity.noContent().build()
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/LectureController.kt
@@ -15,13 +15,13 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import team.msg.domain.lecture.mapper.LectureRequestMapper
-import team.msg.domain.lecture.presentation.data.response.SignedUpLecturesResponse
 import team.msg.domain.lecture.presentation.data.response.DepartmentsResponse
 import team.msg.domain.lecture.presentation.data.response.DivisionsResponse
 import team.msg.domain.lecture.presentation.data.response.InstructorsResponse
-import team.msg.domain.lecture.presentation.data.response.LecturesResponse
 import team.msg.domain.lecture.presentation.data.response.LectureDetailsResponse
+import team.msg.domain.lecture.presentation.data.response.LecturesResponse
 import team.msg.domain.lecture.presentation.data.response.LinesResponse
+import team.msg.domain.lecture.presentation.data.response.SignedUpLecturesResponse
 import team.msg.domain.lecture.presentation.data.response.SignedUpStudentsResponse
 import team.msg.domain.lecture.presentation.data.web.CreateLectureWebRequest
 import team.msg.domain.lecture.presentation.data.web.QueryAllDepartmentsWebRequest
@@ -45,8 +45,8 @@ class LectureController(
     }
 
     @GetMapping
-    fun queryAllLectures(pageable: Pageable, WebRequest: QueryAllLecturesWebRequest): ResponseEntity<LecturesResponse>{
-        val request = lectureRequestMapper.queryLectureWebRequestToDto(WebRequest)
+    fun queryAllLectures(pageable: Pageable, webRequest: QueryAllLecturesWebRequest): ResponseEntity<LecturesResponse>{
+        val request = lectureRequestMapper.queryLectureWebRequestToDto(webRequest)
         val response = lectureService.queryAllLectures(pageable, request)
         return ResponseEntity.status(HttpStatus.OK).body(response)
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/QueryAllLinesWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/presentation/data/web/QueryAllLinesWebRequest.kt
@@ -1,7 +1,5 @@
 package team.msg.domain.lecture.presentation.data.web
 
-import javax.persistence.EnumType
-import javax.persistence.Enumerated
 import org.springframework.web.bind.annotation.RequestParam
 
 data class QueryAllLinesWebRequest (

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureService.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureService.kt
@@ -19,7 +19,7 @@ import java.util.UUID
 
 interface LectureService {
     fun createLecture(request: CreateLectureRequest)
-    fun queryAllLectures(pageable: Pageable, queryAllLectureRequest: QueryAllLectureRequest): LecturesResponse
+    fun queryAllLectures(pageable: Pageable,request: QueryAllLectureRequest): LecturesResponse
     fun queryLectureDetails(id: UUID): LectureDetailsResponse
     fun queryAllLines(request: QueryAllLinesRequest): LinesResponse
     fun queryAllDepartments(request: QueryAllDepartmentsRequest): DepartmentsResponse

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -70,7 +70,6 @@ class LectureServiceImpl(
     private val studentRepository: StudentRepository,
     private val teacherRepository: TeacherRepository,
     private val bbozzakRepository: BbozzakRepository,
-    private val professorRepository: ProfessorRepository,
     private val userRepository: UserRepository,
     private val clubRepository: ClubRepository,
     private val schoolRepository: SchoolRepository,
@@ -435,7 +434,7 @@ class LectureServiceImpl(
         registeredLectureRepository.save(updatedRegisteredLecture)
     }
 
-    @Transactional(readOnly = true,rollbackFor = [Exception::class])
+    @Transactional(readOnly = true, rollbackFor = [Exception::class])
     override fun lectureReceiptStatusExcel(response: HttpServletResponse) {
         val workBook = XSSFWorkbook()
 
@@ -557,6 +556,7 @@ class LectureServiceImpl(
         cell.cellStyle = style
         this.heightInPoints = height
     }
+
     private infix fun LectureRepository.findById(id: UUID): Lecture = this.findByIdOrNull(id)
         ?: throw LectureNotFoundException("존재하지 않는 강의입니다. info : [ lectureId = $id ]")
 
@@ -576,5 +576,5 @@ class LectureServiceImpl(
         ?: throw UserNotFoundException("유저를 찾을 수 없습니다. info : [ userId = $id ]")
 
     private infix fun TeacherRepository.findByClub(club: Club): Teacher = this.findByClub(club)
-        ?: throw TeacherNotFoundException("해당 동아리의 취업 동아리 선생님을 찾을 수 없습니다. info : [ clubname = ${club.name} ]")
+        ?: throw TeacherNotFoundException("해당 동아리의 취업 동아리 선생님을 찾을 수 없습니다. info : [ club = ${club.name} ]")
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -1,6 +1,5 @@
 package team.msg.domain.lecture.service
 
-import javax.servlet.http.HttpServletResponse
 import org.apache.poi.ss.usermodel.HorizontalAlignment
 import org.apache.poi.ss.usermodel.VerticalAlignment
 import org.apache.poi.xssf.usermodel.XSSFCellStyle
@@ -18,29 +17,12 @@ import team.msg.domain.bbozzak.repository.BbozzakRepository
 import team.msg.domain.club.model.Club
 import team.msg.domain.club.repository.ClubRepository
 import team.msg.domain.lecture.enums.LectureStatus
-import team.msg.domain.lecture.exception.AlreadySignedUpLectureException
-import team.msg.domain.lecture.exception.ForbiddenSignedUpLectureException
-import team.msg.domain.lecture.exception.LectureNotFoundException
-import team.msg.domain.lecture.exception.NotAvailableSignUpDateException
-import team.msg.domain.lecture.exception.OverMaxRegisteredUserException
-import team.msg.domain.lecture.exception.UnSignedUpLectureException
+import team.msg.domain.lecture.exception.*
 import team.msg.domain.lecture.model.Lecture
 import team.msg.domain.lecture.model.LectureDate
 import team.msg.domain.lecture.model.RegisteredLecture
-import team.msg.domain.lecture.presentation.data.request.CreateLectureRequest
-import team.msg.domain.lecture.presentation.data.request.QueryAllDepartmentsRequest
-import team.msg.domain.lecture.presentation.data.request.QueryAllDivisionsRequest
-import team.msg.domain.lecture.presentation.data.request.QueryAllLectureRequest
-import team.msg.domain.lecture.presentation.data.request.QueryAllLinesRequest
-import team.msg.domain.lecture.presentation.data.response.DepartmentsResponse
-import team.msg.domain.lecture.presentation.data.response.DivisionsResponse
-import team.msg.domain.lecture.presentation.data.response.InstructorsResponse
-import team.msg.domain.lecture.presentation.data.response.LectureDetailsResponse
-import team.msg.domain.lecture.presentation.data.response.LectureResponse
-import team.msg.domain.lecture.presentation.data.response.LecturesResponse
-import team.msg.domain.lecture.presentation.data.response.LinesResponse
-import team.msg.domain.lecture.presentation.data.response.SignedUpLecturesResponse
-import team.msg.domain.lecture.presentation.data.response.SignedUpStudentsResponse
+import team.msg.domain.lecture.presentation.data.request.*
+import team.msg.domain.lecture.presentation.data.response.*
 import team.msg.domain.lecture.repository.LectureDateRepository
 import team.msg.domain.lecture.repository.LectureRepository
 import team.msg.domain.lecture.repository.RegisteredLectureRepository
@@ -60,6 +42,7 @@ import team.msg.domain.user.repository.UserRepository
 import java.time.LocalDateTime
 import java.util.*
 import java.util.concurrent.TimeUnit
+import javax.servlet.http.HttpServletResponse
 
 @Service
 class LectureServiceImpl(

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -32,7 +32,6 @@ import team.msg.domain.lecture.presentation.data.request.QueryAllDepartmentsRequ
 import team.msg.domain.lecture.presentation.data.request.QueryAllDivisionsRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLectureRequest
 import team.msg.domain.lecture.presentation.data.request.QueryAllLinesRequest
-import team.msg.domain.lecture.presentation.data.response.SignedUpLecturesResponse
 import team.msg.domain.lecture.presentation.data.response.DepartmentsResponse
 import team.msg.domain.lecture.presentation.data.response.DivisionsResponse
 import team.msg.domain.lecture.presentation.data.response.InstructorsResponse
@@ -40,11 +39,11 @@ import team.msg.domain.lecture.presentation.data.response.LectureDetailsResponse
 import team.msg.domain.lecture.presentation.data.response.LectureResponse
 import team.msg.domain.lecture.presentation.data.response.LecturesResponse
 import team.msg.domain.lecture.presentation.data.response.LinesResponse
+import team.msg.domain.lecture.presentation.data.response.SignedUpLecturesResponse
 import team.msg.domain.lecture.presentation.data.response.SignedUpStudentsResponse
 import team.msg.domain.lecture.repository.LectureDateRepository
 import team.msg.domain.lecture.repository.LectureRepository
 import team.msg.domain.lecture.repository.RegisteredLectureRepository
-import team.msg.domain.professor.repository.ProfessorRepository
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.school.exception.SchoolNotFoundException
 import team.msg.domain.school.repository.SchoolRepository

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -256,6 +256,7 @@ class LectureServiceImpl(
 
         studentRepository.save(updateCreditStudent)
     }
+
     /**
      * 강의에 대해 수강신청 취소하는 비지니스 로직입니다.
      * @param 수강신청을 취소하기 위한 강의 id

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/PostController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/PostController.kt
@@ -44,8 +44,8 @@ class PostController(
     }
 
     @GetMapping("/all")
-    fun queryPosts(queryAllPostsWebRequest: QueryAllPostsWebRequest): ResponseEntity<PostsResponse> {
-        val request = postRequestMapper.queryAllPostsWebRequestToDto(queryAllPostsWebRequest)
+    fun queryPosts(webRequest: QueryAllPostsWebRequest): ResponseEntity<PostsResponse> {
+        val request = postRequestMapper.queryAllPostsWebRequestToDto(webRequest)
         val response = postService.queryPosts(request)
         return ResponseEntity.ok(response)
     }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/PostController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/presentation/PostController.kt
@@ -40,32 +40,32 @@ class PostController(
     @GetMapping
     fun queryPosts(@RequestParam type: FeedType, pageable: Pageable): ResponseEntity<PagingPostsResponse> {
         val response = postService.queryPosts(type, pageable)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/all")
     fun queryPosts(queryAllPostsWebRequest: QueryAllPostsWebRequest): ResponseEntity<PostsResponse> {
         val request = postRequestMapper.queryAllPostsWebRequestToDto(queryAllPostsWebRequest)
         val response = postService.queryPosts(request)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/{id}")
     fun queryPostDetails(@PathVariable id: UUID): ResponseEntity<PostDetailsResponse> {
         val response = postService.queryPostDetails(id)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @PatchMapping("/{id}")
     fun updatePost(@PathVariable id: UUID, @RequestBody @Valid webRequest: UpdatePostWebRequest): ResponseEntity<Void> {
         val request = postRequestMapper.updatePostWebRequestToDto(webRequest)
         postService.updatePost(id, request)
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+        return ResponseEntity.noContent().build()
     }
 
     @DeleteMapping("/{id}")
     fun deletePost(@PathVariable id: UUID): ResponseEntity<Void> {
         postService.deletePost(id)
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+        return ResponseEntity.noContent().build()
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
@@ -28,6 +28,7 @@ class PostServiceImpl(
     private val userRepository: UserRepository,
     private val userUtil: UserUtil
 ) : PostService {
+
     /**
      * 게시글을 생성하는 비지니스 로직입니다.
      * @param 게시글 생성에 필요한 정보가 담긴 dto

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/school/presentation/SchoolController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/school/presentation/SchoolController.kt
@@ -1,6 +1,5 @@
 package team.msg.domain.school.presentation
 
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -16,6 +15,6 @@ class SchoolController(
     @GetMapping
     fun querySchools(): ResponseEntity<SchoolsResponse> {
         val response = schoolService.querySchools()
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/exception/ForbiddenStudentActivityException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/exception/ForbiddenStudentActivityException.kt
@@ -5,5 +5,4 @@ import team.msg.global.error.exception.BitgouelException
 
 class ForbiddenStudentActivityException(
     message: String
-) : BitgouelException(message, StudentActivityErrorCode.FORBIDDEN_STUDENT_ACTIVITY.status) {
-}
+) : BitgouelException(message, StudentActivityErrorCode.FORBIDDEN_STUDENT_ACTIVITY.status)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/exception/StudentActivityNotFoundException.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/exception/StudentActivityNotFoundException.kt
@@ -5,5 +5,4 @@ import team.msg.global.error.exception.BitgouelException
 
 class StudentActivityNotFoundException(
     message: String
-) : BitgouelException(message, StudentActivityErrorCode.STUDENT_ACTIVITY_NOT_FOUND.status) {
-}
+) : BitgouelException(message, StudentActivityErrorCode.STUDENT_ACTIVITY_NOT_FOUND.status)

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/StudentActivityController.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/StudentActivityController.kt
@@ -37,36 +37,36 @@ class StudentActivityController(
     fun updateStudentActivity(@PathVariable id: UUID, @RequestBody @Valid webRequest: UpdateStudentActivityWebRequest): ResponseEntity<Void> {
         val request = studentActivityMapper.updateStudentActivityWebRequestToDto(webRequest)
         studentActivityService.updateStudentActivity(id, request)
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+        return ResponseEntity.noContent().build()
     }
 
     @DeleteMapping("/{id}")
     fun deleteStudentActivity(@PathVariable id: UUID): ResponseEntity<Void> {
         studentActivityService.deleteStudentActivity(id)
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build()
+        return ResponseEntity.noContent().build()
     }
 
     @GetMapping
     fun queryAllStudentActivities(pageable: Pageable): ResponseEntity<StudentActivitiesResponse> {
         val response = studentActivityService.queryAllStudentActivities(pageable)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/{student_id}")
     fun queryStudentActivitiesByStudent(@PathVariable("student_id") studentId: UUID, pageable: Pageable): ResponseEntity<StudentActivitiesResponse> {
         val response = studentActivityService.queryStudentActivitiesByStudent(studentId, pageable)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/my")
     fun queryMyStudentActivities(pageable: Pageable): ResponseEntity<StudentActivitiesResponse> {
         val response = studentActivityService.queryMyStudentActivities(pageable)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping("/{id}/detail")
     fun queryStudentActivityDetail(@PathVariable id: UUID): ResponseEntity<StudentActivityDetailsResponse> {
         val response = studentActivityService.queryStudentActivityDetail(id)
-        return ResponseEntity.status(HttpStatus.OK).body(response)
+        return ResponseEntity.ok(response)
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentActivityResponse.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/response/StudentActivityResponse.kt
@@ -1,7 +1,6 @@
 package team.msg.domain.student.presentation.data.response
 
 import org.springframework.data.domain.Page
-import team.msg.common.enums.ApproveStatus
 import team.msg.domain.student.model.StudentActivity
 import team.msg.domain.user.model.User
 import java.time.LocalDate

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/web/UpdateStudentActivityWebRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/presentation/data/web/UpdateStudentActivityWebRequest.kt
@@ -1,7 +1,6 @@
 package team.msg.domain.student.presentation.data.web
 
 import com.fasterxml.jackson.annotation.JsonFormat
-import javax.validation.constraints.Max
 import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
 import javax.validation.constraints.Size

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -211,9 +211,6 @@ class StudentActivityServiceImpl(
         return response
     }
 
-    /**
-     * find ?: throw 로직을 단순화시킨 infix 함수들입니다.
-     */
     private infix fun StudentRepository.findByUser(user: User): Student =
         this.findByUser(user) ?: throw StudentNotFoundException("학생을 찾을 수 없습니다. info : [ userId = ${user.id} ]")
 

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/user/service/UserServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/user/service/UserServiceImpl.kt
@@ -21,7 +21,7 @@ class UserServiceImpl(
      * 현재 로그인한 유저의 마이페이지를 조회하는 비지니스 로직입니다.
      * @return 조회한 마이페이지 정보가 담긴 dto
      */
-    @Transactional(rollbackFor = [Exception::class], readOnly = true)
+    @Transactional(readOnly = true)
     override fun queryUserPage(): UserPageResponse {
         val user = userUtil.queryCurrentUser()
         val organization = userUtil.getAuthorityEntityAndOrganization(user).second

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/withdraw/service/WithdrawServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/withdraw/service/WithdrawServiceImpl.kt
@@ -13,7 +13,6 @@ class WithdrawServiceImpl(
     private val withdrawStudentRepository: WithdrawStudentRepository
 ) : WithdrawService {
 
-
     /**
      * 탈퇴예정 학생들을 기수로 검색하는 비즈니스 로직
      * @param 학생 기수

--- a/bitgouel-api/src/main/kotlin/team/msg/global/config/RedisConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/config/RedisConfig.kt
@@ -21,7 +21,7 @@ class RedisConfig(
         val redisTemplate = RedisTemplate<String, Int>()
         redisTemplate.keySerializer = StringRedisSerializer()
         redisTemplate.valueSerializer = StringRedisSerializer()
-        redisTemplate.connectionFactory = redisConnectionFactory()
+        redisTemplate.setConnectionFactory(redisConnectionFactory())
         return redisTemplate
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/global/config/RedisConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/config/RedisConfig.kt
@@ -21,7 +21,7 @@ class RedisConfig(
         val redisTemplate = RedisTemplate<String, Int>()
         redisTemplate.keySerializer = StringRedisSerializer()
         redisTemplate.valueSerializer = StringRedisSerializer()
-        redisTemplate.setConnectionFactory(redisConnectionFactory())
+        redisTemplate.connectionFactory = redisConnectionFactory()
         return redisTemplate
     }
 }

--- a/bitgouel-api/src/main/kotlin/team/msg/global/config/properties/EmailProperties.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/config/properties/EmailProperties.kt
@@ -5,7 +5,7 @@ import org.springframework.boot.context.properties.ConstructorBinding
 
 @ConstructorBinding
 @ConfigurationProperties(prefix = "spring.mail")
-class EmailProperties (
+class EmailProperties(
     val host: String,
     val port: Int,
     val username: String,

--- a/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/global/security/SecurityConfig.kt
@@ -20,7 +20,6 @@ class SecurityConfig(
     private val jwtTokenParser: JwtTokenParser
 ) {
     companion object {
-        const val USER = "USER"
         const val ADMIN = "ADMIN"
         const val STUDENT = "STUDENT"
         const val TEACHER = "TEACHER"

--- a/bitgouel-api/src/main/resources/application.yml
+++ b/bitgouel-api/src/main/resources/application.yml
@@ -39,9 +39,9 @@ spring:
             enable: true
             required: true
           auth: true
-          connectiontimeout: 5000
+          connection-timeout: 5000
           timeout: 5000
-          writetimeout: 5000
+          write timeout: 5000
 
 jwt:
   accessSecret: ${JWT_ACCESS:bXNnbXNnbXNnbXNnbXNnbXNnbXNnbXNnbXNn}

--- a/bitgouel-api/src/main/resources/application.yml
+++ b/bitgouel-api/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 server:
   port: ${SERVER_PORT:8080}
   tomcat:
-    mbeanregistry:
+    reregistration:
       enabled: true
 
 spring:

--- a/bitgouel-api/src/test/kotlin/team/msg/BitgouelApplicationTests.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/BitgouelApplicationTests.kt
@@ -10,5 +10,4 @@ class BitgouelApplicationTests {
     fun contextLoads() {
     }
 
-
 }

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/auth/service/AuthServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/auth/service/AuthServiceImplTest.kt
@@ -14,6 +14,7 @@ import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import team.msg.common.enums.ApproveStatus
 import team.msg.common.util.SecurityUtil
+import team.msg.common.util.StudentUtil
 import team.msg.common.util.UserUtil
 import team.msg.domain.auth.exception.InvalidRefreshTokenException
 import team.msg.domain.auth.exception.MisMatchPasswordException
@@ -80,6 +81,7 @@ class AuthServiceImplTest : BehaviorSpec({
     val applicationEventPublisher = mockk<ApplicationEventPublisher>()
     val bbozzakRepository = mockk<BbozzakRepository>()
     val emailAuthenticationRepository = mockk<EmailAuthenticationRepository>()
+    val studentUtil = mockk<StudentUtil>()
     val authServiceImpl = AuthServiceImpl(
         userRepository,
         securityUtil,
@@ -96,7 +98,8 @@ class AuthServiceImplTest : BehaviorSpec({
         emailAuthenticationRepository,
         userUtil,
         applicationEventPublisher,
-        bbozzakRepository
+        bbozzakRepository,
+        studentUtil
     )
 
     // studentSignUp 테스트 코드

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/faq/service/FaqServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/faq/service/FaqServiceImplTest.kt
@@ -5,7 +5,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldNotBeSameInstanceAs
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
@@ -18,28 +18,15 @@ import team.msg.domain.club.model.Club
 import team.msg.domain.club.repository.ClubRepository
 import team.msg.domain.lecture.enums.LectureStatus
 import team.msg.domain.lecture.enums.Semester
-import team.msg.domain.lecture.exception.AlreadySignedUpLectureException
-import team.msg.domain.lecture.exception.ForbiddenSignedUpLectureException
-import team.msg.domain.lecture.exception.NotAvailableSignUpDateException
-import team.msg.domain.lecture.exception.OverMaxRegisteredUserException
-import team.msg.domain.lecture.exception.UnSignedUpLectureException
+import team.msg.domain.lecture.exception.*
 import team.msg.domain.lecture.model.Lecture
 import team.msg.domain.lecture.model.LectureDate
 import team.msg.domain.lecture.model.RegisteredLecture
-import team.msg.domain.lecture.presentation.data.request.CreateLectureRequest
-import team.msg.domain.lecture.presentation.data.request.QueryAllDepartmentsRequest
-import team.msg.domain.lecture.presentation.data.request.QueryAllDivisionsRequest
-import team.msg.domain.lecture.presentation.data.request.QueryAllLectureRequest
-import team.msg.domain.lecture.presentation.data.request.QueryAllLinesRequest
-import team.msg.domain.lecture.presentation.data.response.InstructorsResponse
-import team.msg.domain.lecture.presentation.data.response.LectureDateResponse
-import team.msg.domain.lecture.presentation.data.response.LectureDetailsResponse
-import team.msg.domain.lecture.presentation.data.response.LectureResponse
-import team.msg.domain.lecture.presentation.data.response.LecturesResponse
+import team.msg.domain.lecture.presentation.data.request.*
+import team.msg.domain.lecture.presentation.data.response.*
 import team.msg.domain.lecture.repository.LectureDateRepository
 import team.msg.domain.lecture.repository.LectureRepository
 import team.msg.domain.lecture.repository.RegisteredLectureRepository
-import team.msg.domain.professor.repository.ProfessorRepository
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.school.model.School
 import team.msg.domain.school.repository.SchoolRepository
@@ -67,7 +54,6 @@ class LectureServiceImplTest : BehaviorSpec({
     val registeredLectureRepository = mockk<RegisteredLectureRepository>()
     val studentRepository = mockk<StudentRepository>()
     val teacherRepository = mockk<TeacherRepository>()
-    val professorRepository = mockk<ProfessorRepository>()
     val userRepository = mockk<UserRepository>()
     val bbozzakRepository = mockk<BbozzakRepository>()
     val clubRepository = mockk<ClubRepository>()
@@ -81,7 +67,6 @@ class LectureServiceImplTest : BehaviorSpec({
         studentRepository,
         teacherRepository,
         bbozzakRepository,
-        professorRepository,
         userRepository,
         clubRepository,
         schoolRepository,
@@ -594,7 +579,7 @@ class LectureServiceImplTest : BehaviorSpec({
     }
 
     // queryInstructors 테스트 코드
-    Given("강사와 keyword가 주어질 때"){
+    Given("강사와 keyword가 주어질 때") {
         val professorUserId = UUID.randomUUID()
         val professorUserName = "professor"
         val professorAuthority = Authority.ROLE_PROFESSOR
@@ -625,7 +610,6 @@ class LectureServiceImplTest : BehaviorSpec({
             property(User::name) { governmentUserName }
             property(User::authority) { governmentAuthority }
         }
-        val governmentId = UUID.randomUUID()
         val governmentName = "governmentName"
         val governmentPair = Pair(governmentUser, governmentName)
         val governmentResponse = LectureResponse.instructorOf(governmentUser, governmentName)
@@ -659,7 +643,7 @@ class LectureServiceImplTest : BehaviorSpec({
     }
 
     // queryAllLines 테스트 코드
-    Given("강의와 Division, keyword가 주어질 때"){
+    Given("강의와 Division, keyword가 주어질 때") {
         val emptyKeyword = ""
         val keyword = "기"
         val division = "자동차 산업"
@@ -1187,4 +1171,5 @@ class LectureServiceImplTest : BehaviorSpec({
             }
         }
     }
+
 })

--- a/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
+++ b/bitgouel-api/src/test/kotlin/team/msg/domain/lecture/service/LectureServiceImplTest.kt
@@ -16,8 +16,6 @@ import team.msg.domain.bbozzak.model.Bbozzak
 import team.msg.domain.bbozzak.repository.BbozzakRepository
 import team.msg.domain.club.model.Club
 import team.msg.domain.club.repository.ClubRepository
-import team.msg.domain.company.model.CompanyInstructor
-import team.msg.domain.government.model.Government
 import team.msg.domain.lecture.enums.LectureStatus
 import team.msg.domain.lecture.enums.Semester
 import team.msg.domain.lecture.exception.AlreadySignedUpLectureException
@@ -41,7 +39,6 @@ import team.msg.domain.lecture.presentation.data.response.LecturesResponse
 import team.msg.domain.lecture.repository.LectureDateRepository
 import team.msg.domain.lecture.repository.LectureRepository
 import team.msg.domain.lecture.repository.RegisteredLectureRepository
-import team.msg.domain.professor.model.Professor
 import team.msg.domain.professor.repository.ProfessorRepository
 import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.school.model.School
@@ -140,7 +137,6 @@ class LectureServiceImplTest : BehaviorSpec({
         val maxRegisteredUser = 5
         val startDate = LocalDateTime.MIN
         val endDate = LocalDateTime.MAX
-        val completeDate = LocalDateTime.MAX
         val lectureStatus = LectureStatus.OPENED
         val semester = Semester.FIRST_YEAR_FALL_SEMESTER
         val division = "division"
@@ -396,10 +392,9 @@ class LectureServiceImplTest : BehaviorSpec({
         val maxRegisteredUser = 5
         val credit = 2
         val headCount = 0
+        val lectureType = "상호학점인정교육과정"
         val startDate = LocalDateTime.MIN
         val endDate = LocalDateTime.MAX
-        val lectureType = "상호학점인정교육과정"
-        val lectureDate = fixture<LectureDate>()
 
         val lecture = fixture<Lecture> {
             property(Lecture::id) { lectureId }
@@ -609,10 +604,6 @@ class LectureServiceImplTest : BehaviorSpec({
             property(User::authority) { professorAuthority }
         }
         val university = "university"
-        val professor = fixture<Professor> {
-            property(Professor::user) { professorUser }
-            property(Professor::university) { university }
-        }
         val professorPair = Pair(professorUser, university)
         val professorResponse = LectureResponse.instructorOf(professorUser, university)
 
@@ -625,10 +616,6 @@ class LectureServiceImplTest : BehaviorSpec({
             property(User::authority) { companyInstructorAuthority }
         }
         val company = "company"
-        val companyInstructor = fixture<CompanyInstructor> {
-            property(CompanyInstructor::user) { companyInstructorUser }
-            property(CompanyInstructor::company) { company }
-        }
         val companyInstructorPair = Pair(companyInstructorUser, company)
         val companyInstructorResponse = LectureResponse.instructorOf(companyInstructorUser, company)
 
@@ -640,11 +627,6 @@ class LectureServiceImplTest : BehaviorSpec({
         }
         val governmentId = UUID.randomUUID()
         val governmentName = "governmentName"
-        val government = fixture<Government> {
-            property(Government::id) { governmentId }
-            property(Government::user) { governmentUser }
-            property(Government::governmentName) { governmentName }
-        }
         val governmentPair = Pair(governmentUser, governmentName)
         val governmentResponse = LectureResponse.instructorOf(governmentUser, governmentName)
 
@@ -826,11 +808,6 @@ class LectureServiceImplTest : BehaviorSpec({
             property(Student::id) { studentId }
             property(Student::club) { clubA }
         }
-        val clubBStudent = fixture<Student> {
-            property(Student::user) { studentBUser }
-            property(Student::id) { studentId }
-            property(Student::club) { clubB }
-        }
 
         val lectureId = UUID.randomUUID()
         val lectureName = "name"
@@ -844,15 +821,6 @@ class LectureServiceImplTest : BehaviorSpec({
             property(Lecture::name) { lectureName }
             property(Lecture::lectureType) { lectureType }
             property(Lecture::instructor) { lecturer }
-        }
-
-        val lectureDate1 = fixture<LectureDate> {
-            property(LectureDate::completeDate) { LocalDate.MIN }
-            property(LectureDate::lecture) { lecture }
-        }
-        val lectureDate2 = fixture<LectureDate> {
-            property(LectureDate::completeDate) { LocalDate.MAX }
-            property(LectureDate::lecture) { lecture }
         }
 
         val lectureAndIsComplete = listOf(Pair(lecture, isComplete))

--- a/bitgouel-batch/src/main/kotlin/team/msg/common/util/ParamUtil.kt
+++ b/bitgouel-batch/src/main/kotlin/team/msg/common/util/ParamUtil.kt
@@ -9,7 +9,7 @@ class ParamUtil {
 
     companion object {
 
-        val format = DateTimeFormatter.ofPattern("yyyy/MM/dd-HH:mm:ss-z")
+        private val format = DateTimeFormatter.ofPattern("yyyy/MM/dd-HH:mm:ss-z")
 
         fun strDateTimeToLocalDateTime(strDateTime: String): LocalDateTime {
             try {

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/admin/repository/AdminRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/admin/repository/AdminRepository.kt
@@ -5,6 +5,6 @@ import team.msg.domain.admin.model.Admin
 import team.msg.domain.user.model.User
 import java.util.UUID
 
-interface AdminRepository : CrudRepository<Admin,UUID> {
+interface AdminRepository : CrudRepository<Admin, UUID> {
     fun findByUser(user: User): Admin?
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/auth/repository/RefreshTokenRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/auth/repository/RefreshTokenRepository.kt
@@ -3,6 +3,4 @@ package team.msg.domain.auth.repository
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.auth.model.RefreshToken
 
-interface RefreshTokenRepository : CrudRepository<RefreshToken, String> {
-
-}
+interface RefreshTokenRepository : CrudRepository<RefreshToken, String>

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/bbozzak/repository/BbozzakRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/bbozzak/repository/BbozzakRepository.kt
@@ -5,6 +5,6 @@ import team.msg.domain.bbozzak.model.Bbozzak
 import team.msg.domain.user.model.User
 import java.util.*
 
-interface BbozzakRepository : CrudRepository<Bbozzak,UUID> {
+interface BbozzakRepository : CrudRepository<Bbozzak, UUID> {
     fun findByUser(user: User): Bbozzak?
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/faq/repository/FaqRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/faq/repository/FaqRepository.kt
@@ -3,5 +3,4 @@ package team.msg.domain.faq.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import team.msg.domain.faq.model.Faq
 
-interface FaqRepository : JpaRepository<Faq, Long> {
-}
+interface FaqRepository : JpaRepository<Faq, Long>

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/custom/impl/CustomInquiryRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/repository/custom/impl/CustomInquiryRepositoryImpl.kt
@@ -5,7 +5,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Repository
 import team.msg.domain.inquiry.enums.AnswerStatus
 import team.msg.domain.inquiry.model.Inquiry
-import team.msg.domain.inquiry.model.QInquiry
 import team.msg.domain.inquiry.model.QInquiry.inquiry
 import team.msg.domain.inquiry.repository.custom.CustomInquiryRepository
 import java.util.*

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/LectureDateRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/LectureDateRepository.kt
@@ -6,6 +6,6 @@ import team.msg.domain.lecture.model.LectureDate
 import team.msg.domain.lecture.repository.custom.CustomLectureDateRepository
 import java.util.*
 
-interface LectureDateRepository : CrudRepository<LectureDate,UUID>, CustomLectureDateRepository {
+interface LectureDateRepository : CrudRepository<LectureDate, UUID>, CustomLectureDateRepository {
     fun findAllByLecture(lecture: Lecture): List<LectureDate>
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/RegisteredLectureRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/RegisteredLectureRepository.kt
@@ -1,26 +1,18 @@
 package team.msg.domain.lecture.repository
 
-import javax.persistence.LockModeType
-import javax.persistence.QueryHint
-import org.springframework.data.jpa.repository.EntityGraph
-import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
-import org.springframework.data.jpa.repository.QueryHints
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.lecture.model.Lecture
 import team.msg.domain.lecture.model.RegisteredLecture
 import team.msg.domain.lecture.repository.custom.CustomRegisteredLectureRepository
 import team.msg.domain.student.model.Student
-import java.util.UUID
+import java.util.*
 
 interface RegisteredLectureRepository : CrudRepository<RegisteredLecture, UUID>, CustomRegisteredLectureRepository {
 
     @Query("SELECT rl FROM RegisteredLecture rl JOIN FETCH rl.student " +
             "JOIN FETCH rl.lecture r WHERE rl.student = :student")
     fun findAllByStudent(student: Student): List<RegisteredLecture>
-    fun existsByStudentAndLecture(student: Student, lecture: Lecture): Boolean
     fun findByStudentAndLecture(student: Student, lecture: Lecture): RegisteredLecture?
-    @EntityGraph(attributePaths = ["student"])
-    fun findAllByLecture(lecture: Lecture): List<RegisteredLecture>
     fun countByLecture(lecture: Lecture): Int
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomLectureRepositoryImpl.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/repository/custom/impl/CustomLectureRepositoryImpl.kt
@@ -36,7 +36,7 @@ class CustomLectureRepositoryImpl(
                 eqLectureType(lectureType)
             ).fetchOne()!!
 
-        return PageImpl(content, pageable, count);
+        return PageImpl(content, pageable, count)
     }
 
     override fun deleteAllByUserId(userId: UUID) {

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/school/repository/SchoolRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/school/repository/SchoolRepository.kt
@@ -5,6 +5,6 @@ import team.msg.domain.school.enums.HighSchool
 import team.msg.domain.school.model.School
 import team.msg.domain.school.repository.custom.CustomSchoolRepository
 
-interface SchoolRepository : CrudRepository<School, Long>,CustomSchoolRepository {
+interface SchoolRepository : CrudRepository<School, Long>, CustomSchoolRepository {
     fun findByHighSchool(highSchool: HighSchool): School?
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/StudentActivityRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/repository/StudentActivityRepository.kt
@@ -12,9 +12,6 @@ import java.util.*
 interface StudentActivityRepository : JpaRepository<StudentActivity, UUID>, CustomStudentActivityRepository {
 
     @EntityGraph(attributePaths = ["student"], type = EntityGraph.EntityGraphType.FETCH)
-    fun findAllByStudent(student: Student): List<StudentActivity>
-
-    @EntityGraph(attributePaths = ["student"], type = EntityGraph.EntityGraphType.FETCH)
     fun findAllByStudent(student: Student, pageable: Pageable): Page<StudentActivity>
 
     @EntityGraph(attributePaths = ["student"], type = EntityGraph.EntityGraphType.FETCH)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/model/User.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/model/User.kt
@@ -15,7 +15,7 @@ class User(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
-    @Column(columnDefinition = "VARCHAR(100) COLLATE utf8mb4_unicode_ci", nullable = false)
+    @Column(columnDefinition = "VARBINARY(100)", nullable = false)
     val email: String,
 
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
@@ -24,7 +24,7 @@ class User(
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
     val phoneNumber: String,
 
-    @Column(columnDefinition = "VARCHAR(255) COLLATE utf8mb4_unicode_ci", nullable = false)
+    @Column(columnDefinition = "VARBINARY(100)", nullable = false)
     val password: String,
 
     @Enumerated(EnumType.STRING)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/model/User.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/model/User.kt
@@ -15,7 +15,7 @@ class User(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
-    @Column(columnDefinition = "VARCHAR(100)", nullable = false)
+    @Column(columnDefinition = "VARCHAR(100) COLLATE utf8mb4_unicode_ci", nullable = false)
     val email: String,
 
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
@@ -24,7 +24,7 @@ class User(
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
     val phoneNumber: String,
 
-    @Column(columnDefinition = "VARCHAR(255)", nullable = false)
+    @Column(columnDefinition = "VARCHAR(255) COLLATE utf8mb4_unicode_ci", nullable = false)
     val password: String,
 
     @Enumerated(EnumType.STRING)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/withdraw/repository/WithdrawStudentRepository.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/withdraw/repository/WithdrawStudentRepository.kt
@@ -3,7 +3,6 @@ package team.msg.domain.withdraw.repository
 import org.springframework.data.repository.CrudRepository
 import team.msg.domain.student.model.Student
 import team.msg.domain.withdraw.model.WithdrawStudent
-import java.util.UUID
 
 interface WithdrawStudentRepository : CrudRepository<WithdrawStudent, Long> {
     fun findByStudentIn(students: List<Student>): List<WithdrawStudent>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     image: prom/prometheus
     container_name: bitgouel-prometheus
     ports:
-      - 9090:9090
+      - "9090:9090"
     volumes:
       - ./env:/etc/prometheus
       - ./env/prometheus/volume:/prometheus
@@ -28,7 +28,7 @@ services:
     image: grafana/grafana
     container_name: bitgouel-grafana
     ports:
-      - 3001:3000
+      - "3001:3000"
     volumes:
       - ./env/grafana/volume:/var/lib/grafana
     restart: always


### PR DESCRIPTION
## 💡 배경 및 개요

전체적인 컨벤션 제어 및 사용하지 않는 코드 삭제

Resolves: #{422}

## 📃 작업내용

ResponseEntity 컨벤션을 맞추었습니다.
WebRequest 및 Request DTO 컨벤션을 맞추었습니다.
띄어쓰기 컨벤션을 맞추었습니다.
사용하지 않는 테스트 코드의 변수를 삭제했습니다.
사용하지 않는 JPA 메서드를 삭제했습니다.
Infix 함수를 적용했습니다.
대소문자 구분이 필요한 Email, Password 필드를 VARBINARY로 변경했습니다.
README 파일 md 문법 수정했습니다.

## 🎸기타
출시에 앞서 컨벤션과 잡다한 오류들을 한 PR에서 처리하려는 게 욕심이었던 것 같네요.. 변경사항이 너무 많아서 죄송합니다..😭