### PR TITLE
🔀 :: 582 엔티티 조회 시 불필요한 메서드 호출 수정

### DIFF
--- a/bitgouel-api/src/main/kotlin/team/msg/common/util/StudentUtil.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/common/util/StudentUtil.kt
@@ -1,6 +1,7 @@
 package team.msg.common.util
 
 import org.springframework.stereotype.Component
+import team.msg.common.ulid.ULIDGenerator
 import team.msg.domain.club.model.Club
 import team.msg.domain.student.enums.StudentRole
 import team.msg.domain.student.model.Student
@@ -16,6 +17,7 @@ class StudentUtil(
     fun createStudent(user: User, club: Club, grade: Int, classRoom: Int, number: Int, admissionNumber: Int, subscriptionGrade: Int) {
         val student = Student(
             id = UUID(0, 0),
+            ulid = ULIDGenerator.generateULID(),
             user = user,
             club = club,
             grade = grade,

--- a/bitgouel-api/src/main/kotlin/team/msg/common/util/UserUtil.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/common/util/UserUtil.kt
@@ -5,6 +5,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import team.msg.common.entity.BaseUUIDEntity
 import team.msg.common.enums.ApproveStatus
+import team.msg.common.ulid.ULIDGenerator
 import team.msg.domain.admin.exception.AdminNotFoundException
 import team.msg.domain.admin.model.Admin
 import team.msg.domain.admin.repository.AdminRepository
@@ -213,6 +214,7 @@ class UserUtil(
         return userRepository.save(
             User(
                 id = UUID(0, 0),
+                ulid = ULIDGenerator.generateULID(),
                 email = email,
                 name = name,
                 phoneNumber = phoneNumber,

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/admin/service/AdminServiceImpl.kt
@@ -42,6 +42,7 @@ import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.util.*
 import javax.servlet.http.HttpServletResponse
+import team.msg.common.ulid.ULIDGenerator
 
 @Service
 class AdminServiceImpl(
@@ -90,6 +91,7 @@ class AdminServiceImpl(
 
             User(
                 id = it.id,
+                ulid = it.ulid,
                 email = it.email,
                 name = it.name,
                 phoneNumber = it.phoneNumber,
@@ -291,6 +293,7 @@ class AdminServiceImpl(
 
             val lecture = Lecture(
                 id = UUID(0, 0),
+                ulid = ULIDGenerator.generateULID(),
                 name = name,
                 content = content,
                 instructor = instructorName,
@@ -314,6 +317,7 @@ class AdminServiceImpl(
                     val timeZone = it.split(" ", "~")
                     LectureDate(
                         id = UUID(0, 0),
+                        ulid = ULIDGenerator.generateULID(),
                         lecture = lecture,
                         completeDate = timeZone[0].toLocalDate(),
                         startTime = timeZone[1].toLocalTime(),

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/auth/service/AuthServiceImpl.kt
@@ -5,6 +5,7 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import team.msg.common.enums.ApproveStatus
+import team.msg.common.ulid.ULIDGenerator
 import team.msg.common.util.SecurityUtil
 import team.msg.common.util.StudentUtil
 import team.msg.common.util.UserUtil
@@ -106,6 +107,7 @@ class AuthServiceImpl(
 
         val teacher = Teacher(
             id = UUID(0, 0),
+            ulid = ULIDGenerator.generateULID(),
             user = user,
             club = club
         )
@@ -130,6 +132,7 @@ class AuthServiceImpl(
 
         val bbozzak = Bbozzak(
             id = UUID(0, 0),
+            ulid = ULIDGenerator.generateULID(),
             user = user,
             club = club
         )
@@ -158,6 +161,7 @@ class AuthServiceImpl(
 
         val professor = Professor(
             id = UUID(0, 0),
+            ulid = ULIDGenerator.generateULID(),
             user = user,
             club = club,
             university = university
@@ -186,6 +190,7 @@ class AuthServiceImpl(
 
         val governmentInstructor = GovernmentInstructor(
             id = UUID(0, 0),
+            ulid = ULIDGenerator.generateULID(),
             user = user,
             club = club,
             government = government,
@@ -216,6 +221,7 @@ class AuthServiceImpl(
 
         val companyInstructor = CompanyInstructor(
             id = UUID(0, 0),
+            ulid = ULIDGenerator.generateULID(),
             user = user,
             club = club,
             company = company
@@ -304,6 +310,7 @@ class AuthServiceImpl(
 
         val modifiedPasswordUser = User(
             id = user.id,
+            ulid = user.ulid,
             email = user.email,
             name = user.name,
             phoneNumber = user.phoneNumber,

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/certification/service/CertificationServiceImpl.kt
@@ -3,6 +3,7 @@ package team.msg.domain.certification.service
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.msg.common.ulid.ULIDGenerator
 import team.msg.common.util.UserUtil
 import team.msg.domain.admin.model.Admin
 import team.msg.domain.bbozzak.exception.BbozzakNotFoundException
@@ -66,6 +67,7 @@ class CertificationServiceImpl(
 
         val certification = Certification(
             id = UUID(0, 0),
+            ulid = ULIDGenerator.generateULID(),
             studentId = student.id,
             name = request.name,
             acquisitionDate = request.acquisitionDate
@@ -145,6 +147,7 @@ class CertificationServiceImpl(
 
         val updateCertification = Certification(
             id = certification.id,
+            ulid = certification.ulid,
             studentId = certification.studentId,
             name = request.name,
             acquisitionDate = request.acquisitionDate

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/request/UpdateInquiryRequest.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/presentation/request/UpdateInquiryRequest.kt
@@ -8,6 +8,7 @@ data class UpdateInquiryRequest(
 ) {
     fun update(inquiry: Inquiry): Inquiry = Inquiry(
         id = inquiry.id,
+        ulid = inquiry.ulid,
         user = inquiry.user,
         question = question,
         questionDetail = questionDetail,

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/inquiry/service/InquiryServiceImpl.kt
@@ -3,6 +3,7 @@ package team.msg.domain.inquiry.service
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.msg.common.ulid.ULIDGenerator
 import team.msg.common.util.UserUtil
 import team.msg.domain.inquiry.enums.AnswerStatus
 import team.msg.domain.inquiry.exception.AlreadyAnsweredInquiryException
@@ -40,6 +41,7 @@ class InquiryServiceImpl(
 
         val inquiry = Inquiry(
             id = UUID(0, 0),
+            ulid = ULIDGenerator.generateULID(),
             user = currentUser,
             question = request.question,
             questionDetail = request.questionDetail,
@@ -171,6 +173,7 @@ class InquiryServiceImpl(
 
         val inquiryAnswer = InquiryAnswer(
             id = UUID(0, 0),
+            ulid = ULIDGenerator.generateULID(),
             answer = request.answer,
             admin = currentUser,
             inquiryId = inquiry.id

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/lecture/service/LectureServiceImpl.kt
@@ -41,6 +41,7 @@ import java.time.LocalDateTime
 import java.util.*
 import java.util.concurrent.TimeUnit
 import javax.servlet.http.HttpServletResponse
+import team.msg.common.ulid.ULIDGenerator
 import team.msg.common.util.KakaoUtil
 import team.msg.domain.lecture.enums.CompleteStatus
 import team.msg.domain.lecture.enums.Semester
@@ -76,6 +77,7 @@ class LectureServiceImpl(
 
         val lecture = Lecture(
             id = UUID(0, 0),
+            ulid = ULIDGenerator.generateULID(),
             user = user,
             name = request.name,
             semester = request.semester,
@@ -97,6 +99,7 @@ class LectureServiceImpl(
         val lectureDates = request.lectureDates.map {
             LectureDate(
                 id = UUID(0, 0),
+                ulid = ULIDGenerator.generateULID(),
                 lecture = savedLecture,
                 completeDate = it.completeDate,
                 startTime = it.startTime,
@@ -137,6 +140,7 @@ class LectureServiceImpl(
 
         val updatedLecture = Lecture(
             id = id,
+            ulid = lecture.ulid,
             user = instructorUser,
             name = request.name,
             semester = semester,
@@ -160,6 +164,7 @@ class LectureServiceImpl(
         val lectureDates = request.lectureDates.map {
             LectureDate(
                 id = UUID(0, 0),
+                ulid = ULIDGenerator.generateULID(),
                 lecture = savedLecture,
                 completeDate = it.completeDate,
                 startTime = it.startTime,
@@ -340,6 +345,7 @@ class LectureServiceImpl(
 
         val registeredLecture = RegisteredLecture(
             id = UUID(0, 0),
+            ulid = ULIDGenerator.generateULID(),
             student = student,
             lecture = lecture
         )
@@ -348,6 +354,7 @@ class LectureServiceImpl(
 
         val updateCreditStudent = Student(
             id = student.id,
+            ulid = student.ulid,
             user = student.user,
             club = student.club,
             grade = student.grade,
@@ -384,6 +391,7 @@ class LectureServiceImpl(
 
         val updateCreditStudent = Student(
             id = student.id,
+            ulid = student.ulid,
             user = student.user,
             club = student.club,
             grade = student.grade,
@@ -563,6 +571,7 @@ class LectureServiceImpl(
 
             RegisteredLecture(
                 id = registeredLecture.id,
+                ulid = registeredLecture.ulid,
                 student = registeredLecture.student,
                 lecture = registeredLecture.lecture,
                 completeStatus = completeStatus
@@ -614,6 +623,7 @@ class LectureServiceImpl(
 
             RegisteredLecture(
                 id = registeredLecture.id,
+                ulid = registeredLecture.ulid,
                 student = registeredLecture.student,
                 lecture = registeredLecture.lecture,
                 completeStatus = CompleteStatus.NOT_COMPLETED_YET

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/post/service/PostServiceImpl.kt
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.msg.common.ulid.ULIDGenerator
 import team.msg.common.util.UserUtil
 import team.msg.domain.post.model.Post
 import team.msg.domain.post.presentation.data.request.CreatePostRequest
@@ -43,6 +44,7 @@ class PostServiceImpl(
         val post = request.run {
             Post(
                 id = UUID(0, 0),
+                ulid = ULIDGenerator.generateULID(),
                 userId = user.id,
                 title = title,
                 content = content,
@@ -78,6 +80,7 @@ class PostServiceImpl(
 
         val updatePost = Post(
             id = post.id,
+            ulid = post.ulid,
             userId = post.userId,
             title = request.title,
             content = request.content,

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/student/service/StudentActivityServiceImpl.kt
@@ -4,6 +4,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.msg.common.ulid.ULIDGenerator
 import team.msg.common.util.UserUtil
 import team.msg.domain.bbozzak.model.Bbozzak
 import team.msg.domain.club.model.Club
@@ -52,6 +53,7 @@ class StudentActivityServiceImpl(
 
         val studentActivity = StudentActivity(
             id = UUID(0, 0),
+            ulid = ULIDGenerator.generateULID(),
             title = request.title,
             content = request.content,
             credit = request.credit,
@@ -81,6 +83,7 @@ class StudentActivityServiceImpl(
 
         val updatedStudentActivity = StudentActivity(
             id = studentActivity.id,
+            ulid = studentActivity.ulid,
             title = request.title,
             content = request.content,
             credit = request.credit,

--- a/bitgouel-api/src/main/kotlin/team/msg/domain/user/service/UserServiceImpl.kt
+++ b/bitgouel-api/src/main/kotlin/team/msg/domain/user/service/UserServiceImpl.kt
@@ -49,6 +49,7 @@ class UserServiceImpl(
 
         val modifiedPasswordUser = User(
             id = user.id,
+            ulid = user.ulid,
             email = user.email,
             name = user.name,
             phoneNumber = user.phoneNumber,

--- a/bitgouel-batch/src/main/kotlin/team/msg/jobs/student/GraduateStudentJobConfiguration.kt
+++ b/bitgouel-batch/src/main/kotlin/team/msg/jobs/student/GraduateStudentJobConfiguration.kt
@@ -175,6 +175,7 @@ class GraduateStudentJobConfiguration(
         return student.run {
             Student(
                 id = id,
+                ulid = ulid,
                 user = user,
                 club = club,
                 classRoom = classRoom,
@@ -192,6 +193,7 @@ class GraduateStudentJobConfiguration(
         return student.run {
             Student(
                 id = id,
+                ulid = ulid,
                 user = user,
                 club = club,
                 classRoom = classRoom,

--- a/bitgouel-domain/src/main/kotlin/team/msg/common/entity/BaseUUIDEntity.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/common/entity/BaseUUIDEntity.kt
@@ -14,11 +14,11 @@ abstract class BaseUUIDEntity(
     @Id
     @Column(columnDefinition = "BINARY(16)", nullable = false)
     @get:JvmName(name = "getIdentifier")
-    open var id: UUID = UUID(0, 0)
-) : BaseTimeEntity(), Persistable<UUID> {
-
+    open var id: UUID = UUID(0, 0),
+    
     @Column(name = "ulid", updatable = false, unique = true)
-    var ulid: String? = ULIDGenerator.generateULID()
+    open var ulid: String
+) : BaseTimeEntity(), Persistable<UUID> {
 
     override fun isNew(): Boolean = (id == UUID(0,0)).also { new ->
         if(new) id = UUID.randomUUID()

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/admin/model/Admin.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/admin/model/Admin.kt
@@ -14,8 +14,10 @@ class Admin(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity(id, ulid)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/bbozzak/model/Bbozzak.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/bbozzak/model/Bbozzak.kt
@@ -15,6 +15,8 @@ class Bbozzak(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -23,4 +25,4 @@ class Bbozzak(
     @JoinColumn(name = "club_id", nullable = false)
     val club: Club
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity(id, ulid)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/certifiacation/model/Certification.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/certifiacation/model/Certification.kt
@@ -12,6 +12,8 @@ class Certification(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @Column(name = "student_id", columnDefinition = "BINARY(16)")
     val studentId: UUID,
 
@@ -21,4 +23,4 @@ class Certification(
     @Column(columnDefinition = "DATE", nullable = false)
     val acquisitionDate: LocalDate
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity(id, ulid)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/company/model/CompanyInstructor.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/company/model/CompanyInstructor.kt
@@ -16,6 +16,8 @@ class CompanyInstructor(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -28,4 +30,4 @@ class CompanyInstructor(
     @JoinColumn(name = "company_id")
     val company: Company
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity(id, ulid)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/government/model/GovernmentInstructor.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/government/model/GovernmentInstructor.kt
@@ -17,6 +17,8 @@ class GovernmentInstructor(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -35,4 +37,4 @@ class GovernmentInstructor(
     @Column(columnDefinition = "VARCHAR(20)", nullable = false)
     val sectors: String
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity(id, ulid)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/model/Inquiry.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/model/Inquiry.kt
@@ -16,6 +16,8 @@ class Inquiry(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @ManyToOne
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User,
@@ -29,7 +31,7 @@ class Inquiry(
     @Enumerated(EnumType.STRING)
     @Column(name = "answer_status", nullable = false)
     var answerStatus: AnswerStatus
-) : BaseUUIDEntity(id) {
+) : BaseUUIDEntity(id, ulid) {
     fun replyInquiry() {
         this.answerStatus = AnswerStatus.ANSWERED
     }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/model/InquiryAnswer.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/inquiry/model/InquiryAnswer.kt
@@ -14,6 +14,8 @@ class InquiryAnswer(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @Column(columnDefinition = "VARCHAR(1000)", nullable = false)
     val answer: String,
 
@@ -24,4 +26,4 @@ class InquiryAnswer(
     @Column(name = "inquiry_id", columnDefinition = "BINARY(16)", nullable = false)
     val inquiryId: UUID
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity(id, ulid)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/Lecture.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/Lecture.kt
@@ -20,6 +20,8 @@ class Lecture(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)", nullable = true)
     val user: User?,
@@ -66,7 +68,7 @@ class Lecture(
 
     @Column(columnDefinition = "TINYINT", nullable = false)
     val isDeleted: Boolean = false
-) : BaseUUIDEntity(id) {
+) : BaseUUIDEntity(id, ulid) {
     fun getLectureStatus(): LectureStatus {
         val currentTime = LocalDateTime.now()
 

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/LectureDate.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/LectureDate.kt
@@ -15,6 +15,8 @@ class LectureDate (
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "lecture_id", columnDefinition = "BINARY(16)")
     val lecture: Lecture,
@@ -27,4 +29,4 @@ class LectureDate (
 
     @Column(nullable = false, updatable = false, columnDefinition = "TIME")
     val endTime: LocalTime
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity(id, ulid)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/RegisteredLecture.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/lecture/model/RegisteredLecture.kt
@@ -18,6 +18,8 @@ class RegisteredLecture(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "student_id", columnDefinition = "BINARY(16)")
     val student: Student,
@@ -29,7 +31,7 @@ class RegisteredLecture(
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "VARCHAR(30)", nullable = false)
     val completeStatus: CompleteStatus = CompleteStatus.NOT_COMPLETED_YET
-) : BaseUUIDEntity(id) {
+) : BaseUUIDEntity(id, ulid) {
 
     fun isComplete() = completeStatus != CompleteStatus.NOT_COMPLETED_YET
 }

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/post/model/Post.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/post/model/Post.kt
@@ -12,6 +12,8 @@ class Post (
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @Column(name = "user_id", columnDefinition = "BINARY(16)")
     val userId: UUID,
 
@@ -36,4 +38,4 @@ class Post (
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
     val feedType: FeedType
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity(id, ulid)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/Student.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/Student.kt
@@ -13,6 +13,8 @@ class Student(
     @get:JvmName(name = "getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -43,4 +45,4 @@ class Student(
     @Column(name = "student_role", columnDefinition = "VARCHAR(10)", nullable = false)
     val studentRole: StudentRole
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity(id, ulid)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivity.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/student/model/StudentActivity.kt
@@ -16,6 +16,8 @@ class StudentActivity(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @Column(columnDefinition = "VARCHAR(100)", nullable = false)
     var title: String,
 
@@ -36,4 +38,4 @@ class StudentActivity(
     @JoinColumn(name = "teacher_id", columnDefinition = "BINARY(16)", nullable = false)
     val teacher: Teacher
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity(id, ulid)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/teacher/model/Teacher.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/teacher/model/Teacher.kt
@@ -15,6 +15,8 @@ class Teacher(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -23,4 +25,4 @@ class Teacher(
     @JoinColumn(name = "club_id", nullable = false)
     val club: Club
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity(id, ulid)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/university/model/Professor.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/university/model/Professor.kt
@@ -16,6 +16,8 @@ class Professor(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", columnDefinition = "BINARY(16)")
     val user: User?,
@@ -28,4 +30,4 @@ class Professor(
     @JoinColumn(name = "university_id")
     val university: University
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity(id, ulid)

--- a/bitgouel-domain/src/main/kotlin/team/msg/domain/user/model/User.kt
+++ b/bitgouel-domain/src/main/kotlin/team/msg/domain/user/model/User.kt
@@ -15,6 +15,8 @@ class User(
     @get:JvmName("getIdentifier")
     override var id: UUID,
 
+    override var ulid: String,
+
     @Column(columnDefinition = "VARBINARY(100)", nullable = false, unique = true)
     val email: String,
 
@@ -35,4 +37,4 @@ class User(
     @Column(columnDefinition = "VARCHAR(10)", nullable = false)
     val approveStatus: ApproveStatus
 
-) : BaseUUIDEntity(id)
+) : BaseUUIDEntity(id, ulid)


### PR DESCRIPTION
## 💡 배경 및 개요

JPA를 사용하여 엔티티를 조회할 경우에 테이블과 매핑되는 객체는 기본 생성자를 통해 인스턴스가 만들어집니다.
데이터가 초기화되기 이전의 시점에 모든 필드는 null 상태인데 코틀린의 엘비스 연산자로 인해 필드의 값에 무의미하게 ULIDGenerator.generateULID()가 호출되고, 이후에 데이터베이스로부터 조회한 값이 채워지게 되는 문제가 발생하였습니다.

![image](https://github.com/user-attachments/assets/a635bf77-429c-4c4e-b6d0-f6923105ea49)

![image](https://github.com/user-attachments/assets/8670d75e-4da2-4aa0-a792-4260754dda40)

[참고 링크](https://kimtaeo0328.notion.site/c12d0b5ecf3d4f50b2794b7605f73828?pvs=4)

Resolves: #582 

## 📃 작업내용
BaseUUIDEntity의 primary constructor에 기존에 있던 String 타입의 ulid 프로퍼티를 추가하였습니다.
BaseUUIDEntity를 상속받는 모든 엔티티에 대하여 String 타입의 ulid 프로퍼티를 오버라이드 하였습니다.
BaseUUIDEntity를 상속받는 모든 엔티티의 생성자에 대하여 ulid 파라미터를 넘기도록 하였습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
ULID 와 현재 사용되는 pk가 가변 필드로 선언된 점이 조금 의문이네요 설계 당시에는 가변필드가 필수적일수밖에 없는 조건이 있을수도 있다 하겠지만 지금은 불변필드로 변경하여도 동작하는데 이상이 없어 보입니다 혹시 아시는 분이 계시다면 말씀해 주세요